### PR TITLE
Calibration endpoint

### DIFF
--- a/server/api/main.py
+++ b/server/api/main.py
@@ -1,9 +1,11 @@
 from fastapi import FastAPI
 from .routers.coach import router as coach_router
+from .routers import calibrate
 
 
 app = FastAPI()
 app.include_router(coach_router)
+app.include_router(calibrate.router)
 
 
 @app.post("/analyze")

--- a/server/api/routers/calibrate.py
+++ b/server/api/routers/calibrate.py
@@ -1,0 +1,9 @@
+from fastapi import APIRouter, Query
+
+router = APIRouter()
+
+
+@router.get("/calibrate")
+def calibrate(a4_width_px: float = Query(..., gt=0)):
+    scale = 0.210 / a4_width_px  # 210 mm = 0.210 m
+    return {"scale_m_per_px": scale}

--- a/server/tests/test_calibrate.py
+++ b/server/tests/test_calibrate.py
@@ -1,0 +1,10 @@
+from server.api.main import app
+from fastapi.testclient import TestClient
+
+
+def test_calibrate_endpoint():
+    c = TestClient(app)
+    r = c.get("/calibrate?a4_width_px=500.0")
+    assert r.status_code == 200
+    assert abs(r.json()["scale_m_per_px"] - (0.210 / 500.0)) < 1e-9
+


### PR DESCRIPTION
## Summary
- add calibration router returning meter-per-pixel scale
- expose calibrate endpoint in FastAPI app
- cover calibrate endpoint with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb2096e4f48326ab076f133ca7befe