### PR TITLE
Calibration + /infer (YOLO optional, detections path in CI)

### DIFF
--- a/golfiq/cv-engine/golfiq_cv/metrics/carry.py
+++ b/golfiq/cv-engine/golfiq_cv/metrics/carry.py
@@ -1,0 +1,7 @@
+import numpy as np
+
+def carry_simple_m(ball_speed_mps: float, launch_deg: float) -> float:
+    """Estimate carry distance in meters using basic projectile motion."""
+    g = 9.81
+    rad = np.deg2rad(launch_deg)
+    return float((ball_speed_mps ** 2) * np.sin(2 * rad) / g)

--- a/golfiq/cv-engine/setup.py
+++ b/golfiq/cv-engine/setup.py
@@ -1,0 +1,7 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="golfiq-cv",
+    version="0.0.0",
+    packages=find_packages(),
+)

--- a/golfiq/docs/INFERENCE_SETUP.md
+++ b/golfiq/docs/INFERENCE_SETUP.md
@@ -1,0 +1,28 @@
+# Inference Setup (v0.9)
+
+## Paths
+- `POST /infer` — två lägen:
+  1) **detections**: skicka färdiga detektioner per frame (CI‑vänligt).  
+  2) **frames_b64**: skicka bildrutor som base64 (kräver YOLO vid runtime).
+
+- `GET /calibrate?a4_width_px=NNN` — ger `scale_m_per_px` (A4 = 0.210 m).
+
+## YOLO‑runtime (valfritt)
+För att aktivera riktig YOLOv8‑inferenz:
+```
+pip install ultralytics pillow
+export YOLO_INFERENCE=true
+export YOLO_MODEL_PATH=/path/to/yolov8n.pt
+```
+Skicka sedan `frames_b64` (t.ex. JPEG‑dataURL).
+
+## Detections‑läge (exempel)
+```json
+{
+  "fps": 120,
+  "scale_m_per_px": 0.002,
+  "mode": "detections",
+  "detections": [
+    {"frame_idx":0,"detections":[{"cls":"club_head","conf":0.9,"x1":100,"y1":500,"x2":120,"y2":520},{"cls":"ball","conf":0.95,"x1":300,"y1":520,"x2":310,"y2":530}]}]
+}
+```

--- a/golfiq/server/api/main.py
+++ b/golfiq/server/api/main.py
@@ -1,0 +1,21 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from .routers import analyze, coach, calibrate, infer
+
+app = FastAPI(title="GolfIQ API", version="0.9.0")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.include_router(analyze.router)
+app.include_router(coach.router)
+app.include_router(calibrate.router)
+app.include_router(infer.router)
+
+@app.get("/healthz")
+def health():
+    return {"ok": True}

--- a/golfiq/server/api/routers/__init__.py
+++ b/golfiq/server/api/routers/__init__.py
@@ -1,0 +1,1 @@
+# package marker

--- a/golfiq/server/api/routers/analyze.py
+++ b/golfiq/server/api/routers/analyze.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.post("/analyze")
+def analyze():
+    """Placeholder analyze endpoint used for health checks and compatibility."""
+    return {"status": "ok"}

--- a/golfiq/server/api/routers/calibrate.py
+++ b/golfiq/server/api/routers/calibrate.py
@@ -1,0 +1,11 @@
+from fastapi import APIRouter, Query
+
+router = APIRouter()
+
+@router.get("/calibrate")
+def calibrate(a4_width_px: float = Query(..., gt=0)):
+    """Return scale in meters per pixel given A4 width in pixels.
+    A4 width = 210 mm = 0.210 m.
+    """
+    scale = 0.210 / a4_width_px
+    return {"scale_m_per_px": scale}

--- a/golfiq/server/api/routers/coach.py
+++ b/golfiq/server/api/routers/coach.py
@@ -1,0 +1,11 @@
+from fastapi import APIRouter
+from ...schemas.coach_req_res import CoachRequest, CoachResponse
+from ...services.coach_llm import generate
+
+router = APIRouter()
+
+@router.post("/coach", response_model=CoachResponse)
+def coach(req: CoachRequest):
+    """Generate coaching feedback based on metrics and notes."""
+    txt = generate(mode=req.mode, metrics=req.metrics, notes=req.notes)
+    return CoachResponse(text=txt)

--- a/golfiq/server/api/routers/infer.py
+++ b/golfiq/server/api/routers/infer.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter
+from ...schemas.infer_req import InferRequest
+from ...schemas.analyze_req_res import AnalyzeResponse
+from ...services.infer_service import run_infer
+
+router = APIRouter()
+
+@router.post("/infer", response_model=AnalyzeResponse)
+def infer(req: InferRequest):
+    return run_infer(req)

--- a/golfiq/server/schemas/__init__.py
+++ b/golfiq/server/schemas/__init__.py
@@ -1,0 +1,3 @@
+"""Pydantic schema definitions for GolfIQ server."""
+
+__all__ = []

--- a/golfiq/server/schemas/analyze_req_res.py
+++ b/golfiq/server/schemas/analyze_req_res.py
@@ -1,0 +1,20 @@
+from pydantic import BaseModel
+from typing import Optional
+
+class AnalyzeMeta(BaseModel):
+    fps: float
+    scale_m_per_px: float
+    calibrated: bool
+    view: Optional[str] = None
+
+class Metrics(BaseModel):
+    club_speed_mps: float
+    ball_speed_mps: float
+    launch_deg: float
+    carry_m: float
+
+class AnalyzeResponse(BaseModel):
+    shot_id: str
+    metrics: Metrics
+    quality: str
+    meta: AnalyzeMeta

--- a/golfiq/server/schemas/coach_req_res.py
+++ b/golfiq/server/schemas/coach_req_res.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel, Field
+from typing import Literal, Optional, Dict, Any
+
+
+class CoachRequest(BaseModel):
+    mode: Literal["short", "detailed", "drill"] = "short"
+    notes: str = ""
+    metrics: Optional[Dict[str, Any]] = None
+
+
+class CoachResponse(BaseModel):
+    text: str = Field(..., description="coach feedback")
+

--- a/golfiq/server/schemas/infer_req.py
+++ b/golfiq/server/schemas/infer_req.py
@@ -1,0 +1,24 @@
+from pydantic import BaseModel
+from typing import List, Optional, Literal
+
+class BBox(BaseModel):
+    cls: str
+    conf: float
+    x1: float
+    y1: float
+    x2: float
+    y2: float
+
+class FrameDetections(BaseModel):
+    frame_idx: int
+    detections: List[BBox]
+
+class InferRequest(BaseModel):
+    fps: float
+    scale_m_per_px: float
+    view: Literal["DTL","FO"] = "DTL"
+    calibrated: bool = False
+    # Choose one of the inputs:
+    detections: Optional[List[FrameDetections]] = None
+    frames_b64: Optional[List[str]] = None  # Optional: data URLs or raw base64 strings
+    mode: Optional[Literal["detections","frames_b64"]] = None

--- a/golfiq/server/services/__init__.py
+++ b/golfiq/server/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service utilities for GolfIQ server."""

--- a/golfiq/server/services/coach_llm.py
+++ b/golfiq/server/services/coach_llm.py
@@ -1,0 +1,56 @@
+import os, httpx, json
+
+
+SYSTEM = "Du är en golfcoach. Ge tydlig, kort feedback baserad på mätdata."
+
+
+def _offline_text(mode: str, notes: str):
+    if mode == "detailed":
+        return "Din launch och hastighet ser lovande ut. Håll händerna lite högre i impact för att minska loft."
+    if mode == "drill":
+        return "Öva 10 slag med jämn rytm (3:1). Fokusera på stabilt huvud och jämn träff."
+    base = "Solid sving! Fortsätt träna konsekvent bollträff."
+    return base + (f" Notering: {notes}" if notes else "")
+
+
+def generate(mode: str = "short", metrics: dict | None = None, notes: str = "") -> str:
+    # Feature flag: kör offline-text om inte aktiverad
+    if os.getenv("COACH_FEATURE", "false").lower() != "true":
+        return _offline_text(mode, notes)
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    model = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+    if not api_key:
+        return _offline_text(mode, notes)
+
+    payload = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": SYSTEM},
+            {
+                "role": "user",
+                "content": json.dumps(
+                    {"mode": mode, "metrics": metrics or {}, "notes": notes},
+                    ensure_ascii=False,
+                ),
+            },
+        ],
+        "max_tokens": 200,
+        "temperature": 0.2,
+    }
+    try:
+        r = httpx.post(
+            "https://api.openai.com/v1/chat/completions",
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            json=payload,
+            timeout=20,
+        )
+        r.raise_for_status()
+        return r.json()["choices"][0]["message"]["content"].strip()
+    except Exception:
+        # Faller tillbaka till offline om något går fel
+        return _offline_text(mode, notes)
+

--- a/golfiq/server/services/infer_service.py
+++ b/golfiq/server/services/infer_service.py
@@ -1,0 +1,71 @@
+from uuid import uuid4
+import os, base64, io
+import numpy as np
+from typing import List
+from ..schemas.infer_req import InferRequest
+from ..schemas.analyze_req_res import AnalyzeResponse, AnalyzeMeta, Metrics
+from ..services.quality_score import quality_score
+from .cv_engine_adapter import compute_metrics
+from golfiq_cv.detectors.base import Detection
+from golfiq_cv.trackers.nn_tracker import track_single_class
+
+def _detections_to_frames(req: InferRequest) -> List[List[Detection]]:
+    frames: List[List[Detection]] = []
+    assert req.detections is not None
+    for fr in sorted(req.detections, key=lambda f: f.frame_idx):
+        dets = []
+        for d in fr.detections:
+            dets.append(Detection(cls=d.cls, conf=d.conf, x1=d.x1, y1=d.y1, x2=d.x2, y2=d.y2))
+        frames.append(dets)
+    return frames
+
+def _frames_to_trajs(frames: List[List[Detection]], fps: float):
+    # Track 'ball' and 'club_head' using the lightweight NN tracker
+    tb = track_single_class(frames, "ball")
+    tc = track_single_class(frames, "club_head")
+    ball = np.array([[i/fps, x, y] for (i,x,y) in tb], dtype=float)
+    club = np.array([[i/fps, x, y] for (i,x,y) in tc], dtype=float)
+    return ball, club
+
+def _decode_images_b64(b64_list: list):
+    images = []
+    for b in b64_list:
+        if "," in b:  # strip data URL prefix
+            b = b.split(",", 1)[1]
+        raw = base64.b64decode(b)
+        try:
+            from PIL import Image  # optional dependency
+            img = Image.open(io.BytesIO(raw)).convert("RGB")
+            images.append(np.array(img))
+        except Exception:
+            # If PIL not available or image corrupted, skip
+            continue
+    return images
+
+def run_infer(req: InferRequest) -> AnalyzeResponse:
+    # Path 1: Detections (CI-friendly; preferred for tests)
+    if (req.mode == "detections") or (req.detections is not None and req.mode is None):
+        frames = _detections_to_frames(req)
+        ball, club = _frames_to_trajs(frames, req.fps)
+    # Path 2: Frames -> YOLO (requires env flag and ultralytics at runtime)
+    elif (req.mode == "frames_b64") or (req.frames_b64 is not None):
+        if os.getenv("YOLO_INFERENCE","false").lower() != "true":
+            # To keep API simple in MVP we raise an exception here
+            from fastapi import HTTPException
+            raise HTTPException(status_code=400, detail="YOLO inference disabled. Set YOLO_INFERENCE=true and provide YOLO_MODEL_PATH.")
+        from golfiq_cv.detectors.yolov8 import YoloV8Detector  # lazy import ultralytics in implementation
+        model_path = os.getenv("YOLO_MODEL_PATH", "yolov8n.pt")
+        det = YoloV8Detector(model_path, class_map={0:"ball",1:"club_head"})
+        images = _decode_images_b64(req.frames_b64 or [])
+        frames = [det.predict(img) for img in images]
+        ball, club = _frames_to_trajs(frames, req.fps)
+    else:
+        from fastapi import HTTPException
+        raise HTTPException(status_code=400, detail="Provide 'detections' or 'frames_b64'.")
+
+    # Compute metrics
+    metrics = compute_metrics(ball, club, req.scale_m_per_px)
+    quality = quality_score(num_points=int(min(len(ball), len(club))), fps=req.fps, calibrated=req.calibrated)
+    meta = AnalyzeMeta(fps=req.fps, scale_m_per_px=req.scale_m_per_px, calibrated=req.calibrated, view=req.view)
+
+    return AnalyzeResponse(shot_id=str(uuid4()), metrics=Metrics(**metrics), quality=quality, meta=meta)

--- a/golfiq/server/services/quality_score.py
+++ b/golfiq/server/services/quality_score.py
@@ -1,0 +1,7 @@
+def quality_score(num_points: int, fps: float, calibrated: bool) -> str:
+    """Return a simple quality assessment string based on available data."""
+    if calibrated and num_points >= 10:
+        return "green"
+    if num_points >= 5:
+        return "yellow"
+    return "red"

--- a/golfiq/server/tests/__init__.py
+++ b/golfiq/server/tests/__init__.py
@@ -1,0 +1,1 @@
+# Test package marker

--- a/golfiq/server/tests/test_calibrate.py
+++ b/golfiq/server/tests/test_calibrate.py
@@ -1,0 +1,9 @@
+from ..api.main import app
+from fastapi.testclient import TestClient
+
+def test_calibrate_endpoint():
+    c = TestClient(app)
+    r = c.get("/calibrate?a4_width_px=500.0")
+    assert r.status_code == 200
+    assert "scale_m_per_px" in r.json()
+    assert abs(r.json()["scale_m_per_px"] - (0.210/500.0)) < 1e-9

--- a/golfiq/server/tests/test_infer_detections.py
+++ b/golfiq/server/tests/test_infer_detections.py
@@ -1,0 +1,47 @@
+from ..api.main import app
+from fastapi.testclient import TestClient
+
+client = TestClient(app)
+
+def test_infer_with_detections():
+    payload = {
+        "fps": 120.0,
+        "scale_m_per_px": 0.002,
+        "view": "DTL",
+        "calibrated": True,
+        "mode": "detections",
+        "detections": [
+            {"frame_idx": 0, "detections": [
+                {"cls":"club_head","conf":0.9,"x1":100,"y1":500,"x2":120,"y2":520},
+                {"cls":"ball","conf":0.95,"x1":300,"y1":520,"x2":310,"y2":530}
+            ]},
+            {"frame_idx": 1, "detections": [
+                {"cls":"club_head","conf":0.9,"x1":120,"y1":498,"x2":140,"y2":518},
+                {"cls":"ball","conf":0.95,"x1":300,"y1":520,"x2":310,"y2":530}
+            ]},
+            {"frame_idx": 2, "detections": [
+                {"cls":"club_head","conf":0.9,"x1":150,"y1":490,"x2":170,"y2":510},
+                {"cls":"ball","conf":0.95,"x1":300,"y1":520,"x2":310,"y2":530}
+            ]},
+            {"frame_idx": 3, "detections": [
+                {"cls":"club_head","conf":0.9,"x1":300,"y1":520,"x2":320,"y2":540},
+                {"cls":"ball","conf":0.95,"x1":300,"y1":520,"x2":310,"y2":530}
+            ]},
+            {"frame_idx": 4, "detections": [
+                {"cls":"club_head","conf":0.9,"x1":320,"y1":522,"x2":340,"y2":542},
+                {"cls":"ball","conf":0.95,"x1":315,"y1":508,"x2":325,"y2":518}
+            ]},
+            {"frame_idx": 5, "detections": [
+                {"cls":"club_head","conf":0.9,"x1":340,"y1":524,"x2":360,"y2":544},
+                {"cls":"ball","conf":0.95,"x1":335,"y1":492,"x2":345,"y2":502}
+            ]}
+        ]
+    }
+    r = client.post("/infer", json=payload)
+    assert r.status_code == 200
+    data = r.json()
+    assert data["quality"] in ["green","yellow","red"]
+    m = data["metrics"]
+    for k in ["club_speed_mps","ball_speed_mps","launch_deg","carry_m"]:
+        assert k in m
+        assert isinstance(m[k], (int, float))


### PR DESCRIPTION
## Summary
- add calibration and inference endpoints to FastAPI app
- include inference service with optional YOLO and detections mode
- package cv-engine and add tests/docs for new endpoints

## Testing
- `python -m pytest cv-engine/tests server/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68bdc218d7ec832692b1114591de5745