### PR TITLE
App UI: Calibrate + Infer demo

### DIFF
--- a/golfiq/app/App.tsx
+++ b/golfiq/app/App.tsx
@@ -1,0 +1,29 @@
+import React, { useState } from 'react';
+import { SafeAreaView, View, Text, TouchableOpacity, StyleSheet, ScrollView } from 'react-native';
+import CalibrateScreen from './src/screens/CalibrateScreen';
+import RecordSwingScreen from './src/screens/RecordSwingScreen';
+
+export default function App(){
+  const [tab, setTab] = useState<'cal'|'rec'>('cal');
+  return (
+    <SafeAreaView style={{flex:1}}>
+      <View style={styles.tabs}>
+        <TouchableOpacity onPress={()=>setTab('cal')} style={[styles.tab, tab==='cal' && styles.tabActive]}>
+          <Text style={styles.tabText}>Kalibrera</Text>
+        </TouchableOpacity>
+        <TouchableOpacity onPress={()=>setTab('rec')} style={[styles.tab, tab==='rec' && styles.tabActive]}>
+          <Text style={styles.tabText}>Analys (demo)</Text>
+        </TouchableOpacity>
+      </View>
+      <ScrollView contentContainerStyle={{padding:16}}>
+        {tab==='cal' ? <CalibrateScreen/> : <RecordSwingScreen/>}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+const styles = StyleSheet.create({
+  tabs:{flexDirection:'row', borderBottomWidth:1, borderColor:'#ddd'},
+  tab:{flex:1, padding:12, alignItems:'center'},
+  tabActive:{borderBottomWidth:3, borderColor:'#111'},
+  tabText:{fontWeight:'600'}
+});

--- a/golfiq/app/README.md
+++ b/golfiq/app/README.md
@@ -1,0 +1,7 @@
+# App UI update (calibrate + infer demo)
+
+- Adds `App.tsx` with two tabs: **Kalibrera** (calls `/calibrate`) and **Analys (demo)** (calls `/infer` in *detections* mode).
+- `lib/api.ts` contains helper functions and a `mockDetections()` generator.
+- Start the server on port 8000, then run the app with `npx expo start` and press the buttons.
+
+> Next step: replace mock detections with real frames from the camera and use `frames_b64` mode when YOLO runtime is enabled.

--- a/golfiq/app/src/components/MetricCard.tsx
+++ b/golfiq/app/src/components/MetricCard.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function MetricCard({title, value, unit}:{title:string, value:number|string, unit?:string}){
+  return (
+    <View style={styles.card}>
+      <Text style={styles.title}>{title}</Text>
+      <Text style={styles.value}>{value}{unit? ' '+unit: ''}</Text>
+    </View>
+  )
+}
+const styles = StyleSheet.create({
+  card:{padding:16, borderRadius:12, backgroundColor:'#f1f1f1', marginBottom:12},
+  title:{fontSize:14, color:'#666'},
+  value:{fontSize:22, fontWeight:'600'}
+});

--- a/golfiq/app/src/lib/api.ts
+++ b/golfiq/app/src/lib/api.ts
@@ -1,0 +1,51 @@
+export const API_BASE = 'http://localhost:8000';
+
+export type ViewKind = 'DTL'|'FO';
+export type Meta = { fps:number; scale_m_per_px:number; calibrated:boolean; view:ViewKind };
+export type Box = { cls:string; conf:number; x1:number; y1:number; x2:number; y2:number; };
+export type DetFrame = { t?:number; dets: Box[] };
+
+export async function calibrate(a4_width_px:number){
+  const url = `${API_BASE}/calibrate?a4_width_px=${a4_width_px}`;
+  const r = await fetch(url);
+  if(!r.ok) throw new Error('Calibrate failed');
+  return await r.json();
+}
+
+export async function inferWithDetections(meta: Meta, detections: DetFrame[]){
+  const payload = { mode: 'detections', detections, meta };
+  const r = await fetch(`${API_BASE}/infer`, {
+    method:'POST',
+    headers:{'Content-Type':'application/json'},
+    body: JSON.stringify(payload)
+  });
+  if(!r.ok) throw new Error('Infer failed');
+  return await r.json();
+}
+
+// Demo: generate tiny synthetic detections seq (like our server test)
+export function mockDetections(): DetFrame[]{
+  const frames: DetFrame[] = [
+    {t:-0.02, dets:[
+      {cls:'club_head', conf:0.9, x1:390,y1:590,x2:410,y2:610},
+      {cls:'ball', conf:0.9, x1:500,y1:600,x2:502,y2:602}
+    ]},
+    {t:-0.01, dets:[
+      {cls:'club_head', conf:0.9, x1:440,y1:560,x2:460,y2:580},
+      {cls:'ball', conf:0.9, x1:500,y1:600,x2:502,y2:602}
+    ]},
+    {t:0.00, dets:[
+      {cls:'club_head', conf:0.9, x1:500,y1:600,x2:520,y2:620},
+      {cls:'ball', conf:0.9, x1:500,y1:600,x2:502,y2:602}
+    ]},
+    {t:0.01, dets:[
+      {cls:'club_head', conf:0.9, x1:530,y1:610,x2:550,y2:630},
+      {cls:'ball', conf:0.9, x1:515,y1:590,x2:517,y2:592}
+    ]},
+    {t:0.02, dets:[
+      {cls:'club_head', conf:0.9, x1:560,y1:620,x2:580,y2:640},
+      {cls:'ball', conf:0.9, x1:530,y1:580,x2:532,y2:582}
+    ]}
+  ];
+  return frames;
+}

--- a/golfiq/app/src/screens/CalibrateScreen.tsx
+++ b/golfiq/app/src/screens/CalibrateScreen.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import { calibrate } from '../lib/api';
+
+export default function CalibrateScreen(){
+  const [px, setPx] = useState('500');
+  const [scale, setScale] = useState<number|null>(null);
+
+  const onCalc = async () => {
+    const x = parseFloat(px);
+    if(!x || x<=0) return;
+    const s = await calibrate(x);
+    setScale(s.scale_m_per_px);
+  };
+
+  return (
+    <View>
+      <Text style={styles.h1}>Kalibrering (A4)</Text>
+      <Text>Fyll i hur många pixlar en A4-bredd motsvarar i din bild. Tips: ta en bild med A4 i bildplanet, 
+      öppna den i valfri app och mät bredden i px – eller använd vår overlay i nästa version.</Text>
+      <View style={{flexDirection:'row', alignItems:'center', marginTop:12}}>
+        <TextInput style={styles.input} keyboardType='numeric' value={px} onChangeText={setPx} />
+        <Button title='Beräkna' onPress={onCalc} />
+      </View>
+      {scale!==null && (
+        <View style={styles.result}>
+          <Text>Skala: <Text style={{fontWeight:'700'}}>{scale.toFixed(6)} m/px</Text></Text>
+        </View>
+      )}
+    </View>
+  )
+}
+const styles = StyleSheet.create({
+  h1:{fontSize:20, fontWeight:'700', marginBottom:8},
+  input:{borderWidth:1, borderColor:'#ccc', padding:8, borderRadius:8, width:120, marginRight:8},
+  result:{marginTop:12, padding:12, backgroundColor:'#f1f1f1', borderRadius:10}
+});

--- a/golfiq/app/src/screens/RecordSwingScreen.tsx
+++ b/golfiq/app/src/screens/RecordSwingScreen.tsx
@@ -1,0 +1,40 @@
+import React, {useState} from 'react';
+import { View, Text, Button } from 'react-native';
+import MetricCard from '../components/MetricCard';
+import { mpsToMph, metersToYards } from '../lib/units';
+import { inferWithDetections, mockDetections, Meta } from '../lib/api';
+
+export default function RecordSwingScreen(){
+  const [result, setResult] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState<string|undefined>();
+
+  const onAnalyze = async () => {
+    setLoading(true); setErr(undefined);
+    try{
+      const meta: Meta = { fps:120, scale_m_per_px:0.002, calibrated:true, view:'DTL' };
+      const detections = mockDetections();
+      const r = await inferWithDetections(meta, detections);
+      setResult(r);
+    } catch(e:any){
+      setErr(String(e?.message || e));
+    } finally { setLoading(false); }
+  };
+
+  return (
+    <View>
+      <Text style={{fontSize:22, fontWeight:'700', marginBottom:12}}>Analys (demo via /infer)</Text>
+      <Button title={loading? 'Analyserar...' : 'Kör demo-analys'} onPress={onAnalyze} />
+      {err && <Text style={{color:'red', marginTop:8}}>{err}</Text>}
+      {result && (
+        <View style={{marginTop:16}}>
+          <MetricCard title="Club speed" value={mpsToMph(result.metrics.club_speed_mps).toFixed(1)} unit="mph" />
+          <MetricCard title="Ball speed" value={mpsToMph(result.metrics.ball_speed_mps).toFixed(1)} unit="mph" />
+          <MetricCard title="Launch" value={result.metrics.launch_deg.toFixed(1)} unit="°" />
+          <MetricCard title="Carry" value={metersToYards(result.metrics.carry_m).toFixed(0)} unit="yd" />
+          <MetricCard title="Quality" value={result.quality} />
+        </View>
+      )}
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary
- add Expo app with tabs for calibration and inference demo
- include API helpers, metric card component, and demo screens
- document app usage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdcdd0ade483268086664ee96a9c7e