### PR TITLE
YOLO runtime setup + frames_b64 client + env support

### DIFF
--- a/golfiq/app/.env.example
+++ b/golfiq/app/.env.example
@@ -1,0 +1,1 @@
+EXPO_PUBLIC_API_BASE=http://localhost:8000

--- a/golfiq/app/src/lib/api.ts
+++ b/golfiq/app/src/lib/api.ts
@@ -1,9 +1,12 @@
-export const API_BASE = 'http://localhost:8000';
+const API_FROM_ENV = process.env.EXPO_PUBLIC_API_BASE || 'http://localhost:8000';
+export const API_BASE = API_FROM_ENV as string;
 
 export type ViewKind = 'DTL'|'FO';
 export type Meta = { fps:number; scale_m_per_px:number; calibrated:boolean; view:ViewKind };
 export type Box = { cls:string; conf:number; x1:number; y1:number; x2:number; y2:number; };
 export type DetFrame = { t?:number; dets: Box[] };
+export type ImgFrame = { t?:number; image_b64: string };
+export type YoloConfig = { model_path:string; class_map?:Record<number,string>; conf?:number };
 
 export async function calibrate(a4_width_px:number){
   const url = `${API_BASE}/calibrate?a4_width_px=${a4_width_px}`;
@@ -15,15 +18,22 @@ export async function calibrate(a4_width_px:number){
 export async function inferWithDetections(meta: Meta, detections: DetFrame[]){
   const payload = { mode: 'detections', detections, meta };
   const r = await fetch(`${API_BASE}/infer`, {
-    method:'POST',
-    headers:{'Content-Type':'application/json'},
-    body: JSON.stringify(payload)
+    method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload)
   });
   if(!r.ok) throw new Error('Infer failed');
   return await r.json();
 }
 
-// Demo: generate tiny synthetic detections seq (like our server test)
+export async function inferWithFrames(meta: Meta, frames: ImgFrame[], yolo: YoloConfig){
+  const payload = { mode: 'frames_b64', frames, meta, yolo };
+  const r = await fetch(`${API_BASE}/infer`, {
+    method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload)
+  });
+  if(!r.ok) throw new Error(`Infer failed (${r.status})`);
+  return await r.json();
+}
+
+
 export function mockDetections(): DetFrame[]{
   const frames: DetFrame[] = [
     {t:-0.02, dets:[

--- a/golfiq/clients/infer_client.py
+++ b/golfiq/clients/infer_client.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Send a folder of images to /infer in frames_b64 mode."""
+import os, base64, argparse, requests
+
+def load_frames(folder):
+    frames = []
+    for name in sorted(os.listdir(folder)):
+        if not name.lower().endswith(('.jpg','.jpeg','.png','.webp')):
+            continue
+        path = os.path.join(folder, name)
+        with open(path, 'rb') as f:
+            b64 = base64.b64encode(f.read()).decode('ascii')
+        frames.append({'image_b64': b64})
+    return frames
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--api', default='http://localhost:8000', help='Server base URL')
+    ap.add_argument('--frames', required=True, help='Folder with images')
+    ap.add_argument('--fps', type=float, default=120.0)
+    ap.add_argument('--scale', type=float, default=0.002)
+    ap.add_argument('--model', required=True, help='Server path to yolov8n.pt')
+    args = ap.parse_args()
+
+    payload = {
+        'mode':'frames_b64',
+        'frames': load_frames(args.frames),
+        'meta': {'fps': args.fps, 'scale_m_per_px': args.scale, 'calibrated': True, 'view':'DTL'},
+        'yolo': {'model_path': args.model, 'class_map': {'0':'ball','1':'club_head'}, 'conf': 0.25}
+    }
+    r = requests.post(args.api + '/infer', json=payload, timeout=60)
+    print(r.status_code, r.text)
+
+if __name__ == '__main__':
+    main()

--- a/golfiq/docs/DRX-InferUpload.md
+++ b/golfiq/docs/DRX-InferUpload.md
@@ -1,0 +1,11 @@
+# DRX: Infer Upload (frames_b64 vs detections)
+
+**Two modes in `/infer`:**
+- `detections`: client sends detections per frame → CI-friendly, no YOLO deps.
+- `frames_b64`: client sends base64 frames → server runs YOLO (production path).
+
+**Why this split?** CI remains lightweight, while production keeps model control and GPU accel on server.
+
+**Contract highlights:**
+- `meta`: {fps, scale_m_per_px, calibrated, view}
+- `yolo` (only for frames_b64): model_path and optional `class_map` (e.g., {0:"ball",1:"club_head"})

--- a/golfiq/docs/RUNTIME_SETUP.md
+++ b/golfiq/docs/RUNTIME_SETUP.md
@@ -1,0 +1,22 @@
+# Runtime Setup (YOLOv8 on server)
+
+To enable `/infer` in **frames_b64** mode:
+
+1. Create and activate a virtualenv (recommended).
+2. Install base deps:
+   ```bash
+   pip install -e cv-engine
+   pip install -r server/requirements.txt
+   ```
+3. Install **YOLO runtime** deps:
+   ```bash
+   pip install -r server/requirements-optional.txt
+   ```
+4. Set environment and start server:
+   ```bash
+   export YOLO_INFERENCE=true
+   export YOLO_MODEL_PATH=/absolute/path/to/yolov8n.pt
+   uvicorn server.api.main:app --reload --port 8000
+   ```
+
+Now the server can accept `POST /infer` with `{ "mode":"frames_b64", "frames":[...], "yolo": {"model_path": "...", "class_map": { "0":"ball","1":"club_head" }}}`.

--- a/golfiq/server/requirements-optional.txt
+++ b/golfiq/server/requirements-optional.txt
@@ -1,0 +1,3 @@
+ultralytics>=8.0.0
+opencv-python>=4.9
+pillow>=10.0


### PR DESCRIPTION
## Summary
- add optional YOLO runtime requirements and client script for sending base64 frames
- document runtime setup and infer upload modes
- expose API base via `.env` and support frames_b64 inference in app client

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bde6b6f7d48326a1f283f43b799e7f