### PR TITLE
App: Kamera → frames_b64 → /infer

### DIFF
--- a/golfiq/app/App.tsx
+++ b/golfiq/app/App.tsx
@@ -2,9 +2,10 @@ import React, { useState } from 'react';
 import { SafeAreaView, View, Text, TouchableOpacity, StyleSheet, ScrollView } from 'react-native';
 import CalibrateScreen from './src/screens/CalibrateScreen';
 import RecordSwingScreen from './src/screens/RecordSwingScreen';
+import CameraInferScreen from './src/screens/CameraInferScreen';
 
 export default function App(){
-  const [tab, setTab] = useState<'cal'|'rec'>('cal');
+  const [tab, setTab] = useState<'cal'|'rec'|'cam'>('cal');
   return (
     <SafeAreaView style={{flex:1}}>
       <View style={styles.tabs}>
@@ -14,9 +15,12 @@ export default function App(){
         <TouchableOpacity onPress={()=>setTab('rec')} style={[styles.tab, tab==='rec' && styles.tabActive]}>
           <Text style={styles.tabText}>Analys (demo)</Text>
         </TouchableOpacity>
+        <TouchableOpacity onPress={()=>setTab('cam')} style={[styles.tab, tab==='cam' && styles.tabActive]}>
+          <Text style={styles.tabText}>Kamera</Text>
+        </TouchableOpacity>
       </View>
       <ScrollView contentContainerStyle={{padding:16}}>
-        {tab==='cal' ? <CalibrateScreen/> : <RecordSwingScreen/>}
+        {tab==='cal' ? <CalibrateScreen/> : tab==='rec' ? <RecordSwingScreen/> : <CameraInferScreen/>}
       </ScrollView>
     </SafeAreaView>
   );

--- a/golfiq/app/package.json
+++ b/golfiq/app/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "golfiq-app",
+  "version": "0.0.2",
+  "private": true,
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "~51.0.0",
+    "expo-status-bar": "~1.12.1",
+    "expo-camera": "~15.0.6",
+    "react": "18.2.0",
+    "react-native": "0.74.3"
+  }
+}

--- a/golfiq/app/src/screens/CameraInferScreen.tsx
+++ b/golfiq/app/src/screens/CameraInferScreen.tsx
@@ -1,0 +1,100 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { View, Text, Button, StyleSheet, TextInput, Alert } from 'react-native';
+import { Camera, CameraType, useCameraPermissions } from 'expo-camera';
+import type { ImgFrame, Meta, YoloConfig } from '../lib/api';
+import { inferWithFrames } from '../lib/api';
+import MetricCard from '../components/MetricCard';
+
+export default function CameraInferScreen(){
+  const [permission, requestPermission] = useCameraPermissions();
+  const [ready, setReady] = useState(false);
+  const [fps, setFps] = useState('120');
+  const [scale, setScale] = useState('0.002'); // m/px (kalibrering)
+  const [serverModelPath, setServerModelPath] = useState('/abs/path/to/yolov8n.pt');
+  const [busy, setBusy] = useState(false);
+  const [result, setResult] = useState<any>(null);
+  const cameraRef = useRef<Camera | null>(null);
+
+  useEffect(()=>{
+    if (!permission) requestPermission();
+  }, [permission]);
+
+  const captureBurst = async (count=12, intervalMs=60): Promise<ImgFrame[]> => {
+    const frames: ImgFrame[] = [];
+    for(let i=0;i<count;i++){
+      try{
+        const pic = await cameraRef.current?.takePictureAsync({ base64:true, quality:0.5, skipProcessing:true });
+        if (pic?.base64) frames.push({ image_b64: pic.base64 });
+      }catch(e){ console.warn('capture error', e); }
+      await new Promise(r => setTimeout(r, intervalMs));
+    }
+    return frames;
+  };
+
+  const onAnalyze = async () => {
+    if (!permission?.granted) { Alert.alert('Kamera', 'Ge kameratillstånd först.'); return; }
+    if (!cameraRef.current) { Alert.alert('Kamera', 'Kameran är inte redo.'); return; }
+    setBusy(true); setResult(null);
+    try{
+      const frames = await captureBurst(12, 60);
+      if (frames.length < 4) { Alert.alert('Kamera', 'Fick för få bilder. Försök igen.'); setBusy(false); return; }
+      const meta: Meta = { fps: parseFloat(fps)||120, scale_m_per_px: parseFloat(scale)||0.002, calibrated:true, view:'DTL' };
+      const yolo: YoloConfig = { model_path: serverModelPath, class_map: {0:'ball',1:'club_head'}, conf: 0.25 };
+      const r = await inferWithFrames(meta, frames, yolo);
+      setResult(r);
+    } catch(e:any){
+      Alert.alert('Fel vid inferens', String(e?.message || e));
+    } finally { setBusy(false); }
+  };
+
+  if (!permission) return <View><Text>Kontrollerar kameratillstånd…</Text></View>;
+  if (!permission.granted){
+    return (
+      <View style={{gap:12}}>
+        <Text>Vi behöver kameratillstånd för att analysera svingen.</Text>
+        <Button title="Ge tillstånd" onPress={requestPermission} />
+      </View>
+    );
+  }
+
+  return (
+    <View>
+      <Text style={styles.h1}>Kamera → /infer (YOLO på server)</Text>
+      <View style={styles.row}>
+        <Text style={styles.label}>FPS</Text>
+        <TextInput style={styles.input} keyboardType="numeric" value={fps} onChangeText={setFps} />
+        <Text style={styles.label}>m/px</Text>
+        <TextInput style={styles.input} keyboardType="numeric" value={scale} onChangeText={setScale} />
+      </View>
+      <View style={{marginTop:8}}>
+        <Text style={styles.label}>Serverns YOLO‑modell (sökväg på servern)</Text>
+        <TextInput style={[styles.input, {width:'100%'}]} value={serverModelPath} onChangeText={setServerModelPath} />
+      </View>
+
+      <View style={{height:320, marginTop:12, borderRadius:12, overflow:'hidden', backgroundColor:'#000'}}>
+        <Camera ref={(r)=> (cameraRef.current = r)} style={{flex:1}} type={CameraType.back} onCameraReady={()=>setReady(true)} />
+      </View>
+
+      <View style={{marginTop:12}}>
+        <Button title={busy? 'Analyserar…' : 'Fånga 12 bilder och analysera'} onPress={onAnalyze} disabled={busy || !ready} />
+      </View>
+
+      {result && (
+        <View style={{marginTop:16}}>
+          <MetricCard title="Club speed" value={(result.metrics.club_speed_mps*2.23693629).toFixed(1)} unit="mph" />
+          <MetricCard title="Ball speed" value={(result.metrics.ball_speed_mps*2.23693629).toFixed(1)} unit="mph" />
+          <MetricCard title="Launch" value={result.metrics.launch_deg.toFixed(1)} unit="°" />
+          <MetricCard title="Carry" value={(result.metrics.carry_m*1.0936133).toFixed(0)} unit="yd" />
+          <MetricCard title="Quality" value={result.quality} />
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  h1:{fontSize:20, fontWeight:'700', marginBottom:8},
+  row:{flexDirection:'row', alignItems:'center', gap:8},
+  label:{fontSize:12, color:'#666'},
+  input:{borderWidth:1, borderColor:'#ccc', padding:8, borderRadius:8, width:90}
+});

--- a/golfiq/docs/APP_CAMERA_SETUP.md
+++ b/golfiq/docs/APP_CAMERA_SETUP.md
@@ -1,0 +1,10 @@
+# App: Kamera → /infer (frames_b64)
+
+Denna skärm (`CameraInferScreen.tsx`) fångar ~12 bilder i en snabb burst, kodar dem till base64 och skickar till serverns `/infer` med `mode=frames_b64`.
+
+## Steg
+1. Sätt serverns IP i appen via `.env` (`EXPO_PUBLIC_API_BASE=http://<server-ip>:8000`) och starta om bundlern.
+2. Se till att servern kör YOLO enligt `docs/RUNTIME_SETUP.md` (YOLO_INFERENCE=true, YOLO_MODEL_PATH satt).
+3. Öppna fliken **Kamera** → fyll i FPS & m/px (från kalibrering) och serverns modell‑sökväg → tryck “Fånga 12 bilder och analysera”.
+
+> Tips: håll kameran stadig och filma *down‑the‑line*. För bättre resultat, höj FPS (om möjligt) och använd kort slutartid.


### PR DESCRIPTION
## Summary
- add Camera tab and inference screen to app
- send base64 frame bursts to server `/infer`
- document camera setup and add Expo camera dependencies

## Testing
- no tests run (per user request)

------
https://chatgpt.com/codex/tasks/task_e_68bfe93b71308326abf4ae92dfa876d2