### PR TITLE
Tracking: SortLite + coverage-aware quality score (CI-safe)

### DIFF
--- a/golfiq/cv-engine/golfiq_cv/trackers/sortlite.py
+++ b/golfiq/cv-engine/golfiq_cv/trackers/sortlite.py
@@ -1,0 +1,50 @@
+from typing import List, Tuple
+from dataclasses import dataclass
+
+@dataclass
+class BBox:
+    x1: float; y1: float; x2: float; y2: float; conf: float
+
+def _iou(a: BBox, b: BBox) -> float:
+    ix1 = max(a.x1, b.x1); iy1 = max(a.y1, b.y1)
+    ix2 = min(a.x2, b.x2); iy2 = min(a.y2, b.y2)
+    iw = max(0.0, ix2 - ix1); ih = max(0.0, iy2 - iy1)
+    inter = iw * ih
+    if inter <= 0:
+        return 0.0
+    aw = max(0.0, a.x2 - a.x1); ah = max(0.0, a.y2 - a.y1)
+    bw = max(0.0, b.x2 - b.x1); bh = max(0.0, b.y2 - b.y1)
+    union = aw*ah + bw*bh - inter
+    if union <= 0:
+        return 0.0
+    return inter / union
+
+def track_single(frames: List[Tuple[float, list]], cls_name: str, iou_thr: float = 0.2):
+    """Return a trajectory [ [t, cx, cy], ... ] and coverage ratio.
+    frames: list of (t, boxes) where box has attributes (cls, conf, x1,y1,x2,y2)
+    """
+    traj = []
+    prev_box = None
+    total = len(frames); used = 0
+    for t, boxes in frames:
+        # collect class boxes
+        candidates = [BBox(b.x1, b.y1, b.x2, b.y2, b.conf) for b in boxes if getattr(b, 'cls', None) == cls_name]
+        if not candidates:
+            continue
+        chosen = None
+        if prev_box is None:
+            # pick highest conf
+            chosen = max(candidates, key=lambda b: b.conf)
+        else:
+            # pick by best IoU, fallback to highest conf if IoU below threshold
+            best = max(candidates, key=lambda b: _iou(prev_box, b))
+            if _iou(prev_box, best) < iou_thr:
+                best = max(candidates, key=lambda b: b.conf)
+            chosen = best
+        cx = (chosen.x1 + chosen.x2) / 2.0
+        cy = (chosen.y1 + chosen.y2) / 2.0
+        traj.append([t, cx, cy])
+        prev_box = chosen
+        used += 1
+    coverage = used / total if total > 0 else 0.0
+    return traj, coverage

--- a/golfiq/docs/DRX-Tracking.md
+++ b/golfiq/docs/DRX-Tracking.md
@@ -1,0 +1,19 @@
+# DRX: Tracking (v0.9)
+
+**Mål:** Stabilare trajectories än enkel NN (nearest neighbor) utan tunga beroenden i CI.
+
+## Alternativ
+- **NN** (default): närmsta centerpunkt – snabbt men kan hoppa.
+- **SortLite** (ny): enkel IoU-baserad associering till tidigare ruta; fallback till högst conf om IoU < tröskel.
+
+## Parametrar
+- `iou_thr` (0.2 default) – hur nära samma ruta måste ligga mellan frames för att räknas som samma objekt.
+- `coverage` – andel frames där vi hade spårning (0..1). Ingår i `quality_score`.
+
+## Quality-score (v2)
+- **Grön**: kalibrerad, ≥60 FPS, ≥4 punkter och coverage ≥0.6
+- **Gul**: ≥30 FPS, ≥3 punkter och coverage ≥0.4
+- **Röd**: annars.
+
+## Nästa steg
+- Byt ut SortLite mot ByteTrack/SORT i runtime (server), men behåll SortLite i CI.

--- a/golfiq/server/api/routers/infer.py
+++ b/golfiq/server/api/routers/infer.py
@@ -1,10 +1,9 @@
 from fastapi import APIRouter
-from ...schemas.infer_req import InferRequest
-from ...schemas.analyze_req_res import AnalyzeResponse
+from ...schemas.infer_req_res import InferRequest, InferResponse
 from ...services.infer_service import run_infer
 
 router = APIRouter()
 
-@router.post("/infer", response_model=AnalyzeResponse)
+@router.post("/infer", response_model=InferResponse)
 def infer(req: InferRequest):
     return run_infer(req)

--- a/golfiq/server/schemas/infer_req_res.py
+++ b/golfiq/server/schemas/infer_req_res.py
@@ -1,0 +1,54 @@
+from pydantic import BaseModel, Field
+from typing import List, Literal, Optional, Dict, Any
+
+class Box(BaseModel):
+    cls: str
+    conf: float
+    x1: float
+    y1: float
+    x2: float
+    y2: float
+
+class DetFrame(BaseModel):
+    t: Optional[float] = None
+    dets: List[Box]
+
+class ImgFrame(BaseModel):
+    t: Optional[float] = None
+    image_b64: str
+
+class Meta(BaseModel):
+    fps: float = 120.0
+    scale_m_per_px: float = 0.002
+    calibrated: bool = False
+    view: Literal["DTL","FO"] = "DTL"
+
+class YoloConfig(BaseModel):
+    model_path: str
+    class_map: Optional[Dict[int,str]] = None
+    conf: float = 0.25
+
+class TrackingConfig(BaseModel):
+    mode: Literal["nn","sortlite"] = "nn"
+    iou_thr: float = 0.2
+    max_jump_px: float = 100.0
+
+class InferRequest(BaseModel):
+    mode: Literal["detections","frames_b64"]
+    detections: Optional[List[DetFrame]] = None
+    frames: Optional[List[ImgFrame]] = None
+    meta: Meta
+    yolo: Optional[YoloConfig] = None
+    tracking: Optional[TrackingConfig] = None
+
+class Metrics(BaseModel):
+    club_speed_mps: float
+    ball_speed_mps: float
+    launch_deg: float
+    carry_m: float
+
+class InferResponse(BaseModel):
+    shot_id: str
+    metrics: Metrics
+    quality: Literal["green","yellow","red"]
+    meta: Meta

--- a/golfiq/server/services/infer_service.py
+++ b/golfiq/server/services/infer_service.py
@@ -1,71 +1,103 @@
+import os, base64
 from uuid import uuid4
-import os, base64, io
+from typing import List, Tuple, Optional
 import numpy as np
-from typing import List
-from ..schemas.infer_req import InferRequest
-from ..schemas.analyze_req_res import AnalyzeResponse, AnalyzeMeta, Metrics
-from ..services.quality_score import quality_score
+
+from ..schemas.infer_req_res import InferRequest, InferResponse, Metrics, Box
+from .quality_score import quality_score
 from .cv_engine_adapter import compute_metrics
-from golfiq_cv.detectors.base import Detection
-from golfiq_cv.trackers.nn_tracker import track_single_class
 
-def _detections_to_frames(req: InferRequest) -> List[List[Detection]]:
-    frames: List[List[Detection]] = []
-    assert req.detections is not None
-    for fr in sorted(req.detections, key=lambda f: f.frame_idx):
-        dets = []
-        for d in fr.detections:
-            dets.append(Detection(cls=d.cls, conf=d.conf, x1=d.x1, y1=d.y1, x2=d.x2, y2=d.y2))
-        frames.append(dets)
-    return frames
+def _frames_to_time(fps: float, t_opt: Optional[float], idx: int) -> float:
+    return float(t_opt if t_opt is not None else (idx / fps))
 
-def _frames_to_trajs(frames: List[List[Detection]], fps: float):
-    # Track 'ball' and 'club_head' using the lightweight NN tracker
-    tb = track_single_class(frames, "ball")
-    tc = track_single_class(frames, "club_head")
-    ball = np.array([[i/fps, x, y] for (i,x,y) in tb], dtype=float)
-    club = np.array([[i/fps, x, y] for (i,x,y) in tc], dtype=float)
-    return ball, club
+def _traj_nn(frames: List[Tuple[float, List[Box]]], cls_name: str):
+    traj = []
+    last_cx, last_cy = None, None
+    used = 0
+    for t, dets in frames:
+        cds = [(d, ((d.x1+d.x2)/2.0, (d.y1+d.y2)/2.0)) for d in dets if d.cls == cls_name]
+        if not cds: continue
+        if last_cx is None:
+            d, (cx, cy) = max(cds, key=lambda x: x[0].conf)
+        else:
+            # nearest neighbor by center
+            best = None; bestd = 1e18; cx=cy=0.0
+            for d, (cx_, cy_) in cds:
+                d2 = (cx_-last_cx)**2 + (cy_-last_cy)**2
+                if d2 < bestd:
+                    bestd = d2; best = (cx_, cy_)
+            cx, cy = best
+        traj.append([t, cx, cy]); last_cx, last_cy = cx, cy; used += 1
+    coverage = used/len(frames) if frames else 0.0
+    return np.array(traj, dtype=float), coverage
 
-def _decode_images_b64(b64_list: list):
-    images = []
-    for b in b64_list:
-        if "," in b:  # strip data URL prefix
-            b = b.split(",", 1)[1]
-        raw = base64.b64decode(b)
-        try:
-            from PIL import Image  # optional dependency
-            img = Image.open(io.BytesIO(raw)).convert("RGB")
-            images.append(np.array(img))
-        except Exception:
-            # If PIL not available or image corrupted, skip
-            continue
-    return images
+def _traj_sortlite(frames: List[Tuple[float, List[Box]]], cls_name: str, iou_thr: float = 0.2):
+    from golfiq_cv.trackers.sortlite import track_single as sort_track
+    # adapt Box to tracker expected structure via simple shim object
+    class Shim:
+        def __init__(self, b: Box):
+            self.cls=b.cls; self.conf=b.conf; self.x1=b.x1; self.y1=b.y1; self.x2=b.x2; self.y2=b.y2
+    frames_shim = [(t, [Shim(b) for b in dets]) for t, dets in frames]
+    traj, coverage = sort_track(frames_shim, cls_name=cls_name, iou_thr=iou_thr)
+    import numpy as np
+    return np.array(traj, dtype=float), coverage
 
-def run_infer(req: InferRequest) -> AnalyzeResponse:
-    # Path 1: Detections (CI-friendly; preferred for tests)
-    if (req.mode == "detections") or (req.detections is not None and req.mode is None):
-        frames = _detections_to_frames(req)
-        ball, club = _frames_to_trajs(frames, req.fps)
-    # Path 2: Frames -> YOLO (requires env flag and ultralytics at runtime)
-    elif (req.mode == "frames_b64") or (req.frames_b64 is not None):
-        if os.getenv("YOLO_INFERENCE","false").lower() != "true":
-            # To keep API simple in MVP we raise an exception here
-            from fastapi import HTTPException
-            raise HTTPException(status_code=400, detail="YOLO inference disabled. Set YOLO_INFERENCE=true and provide YOLO_MODEL_PATH.")
-        from golfiq_cv.detectors.yolov8 import YoloV8Detector  # lazy import ultralytics in implementation
-        model_path = os.getenv("YOLO_MODEL_PATH", "yolov8n.pt")
-        det = YoloV8Detector(model_path, class_map={0:"ball",1:"club_head"})
-        images = _decode_images_b64(req.frames_b64 or [])
-        frames = [det.predict(img) for img in images]
-        ball, club = _frames_to_trajs(frames, req.fps)
+def _build_trajs(frames: List[Tuple[float, List[Box]]], tracking_cfg) -> tuple[np.ndarray, np.ndarray, float]:
+    mode = (tracking_cfg.mode if tracking_cfg else "nn")
+    if mode == "sortlite":
+        iou_thr = tracking_cfg.iou_thr if tracking_cfg else 0.2
+        ball, cov_ball = _traj_sortlite(frames, "ball", iou_thr=iou_thr)
+        club, cov_club = _traj_sortlite(frames, "club_head", iou_thr=iou_thr)
     else:
-        from fastapi import HTTPException
-        raise HTTPException(status_code=400, detail="Provide 'detections' or 'frames_b64'.")
+        ball, cov_ball = _traj_nn(frames, "ball")
+        club, cov_club = _traj_nn(frames, "club_head")
+    coverage = min(cov_ball, cov_club)
+    return ball, club, coverage
 
-    # Compute metrics
-    metrics = compute_metrics(ball, club, req.scale_m_per_px)
-    quality = quality_score(num_points=int(min(len(ball), len(club))), fps=req.fps, calibrated=req.calibrated)
-    meta = AnalyzeMeta(fps=req.fps, scale_m_per_px=req.scale_m_per_px, calibrated=req.calibrated, view=req.view)
+def run_inference_from_detections(req: InferRequest) -> InferResponse:
+    assert req.detections is not None
+    frames = []
+    for idx, f in enumerate(req.detections):
+        t = _frames_to_time(req.meta.fps, f.t, idx)
+        frames.append((t, f.dets))
+    ball, club, coverage = _build_trajs(frames, req.tracking)
+    metrics = compute_metrics(ball=ball, club=club, scale_m_per_px=req.meta.scale_m_per_px)
+    q = quality_score(num_points=min(len(ball), len(club)), fps=req.meta.fps, calibrated=req.meta.calibrated, coverage=coverage)
+    return InferResponse(shot_id=str(uuid4()), metrics=Metrics(**metrics), quality=q, meta=req.meta)
 
-    return AnalyzeResponse(shot_id=str(uuid4()), metrics=Metrics(**metrics), quality=quality, meta=meta)
+def run_inference_from_frames_b64(req: InferRequest) -> InferResponse:
+    if os.getenv("YOLO_INFERENCE","false").lower() != "true":
+        raise NotImplementedError("YOLO inference disabled. Set YOLO_INFERENCE=true and provide YOLO model.")
+    try:
+        from golfiq_cv.detectors.yolov8 import YoloV8Detector  # type: ignore
+        import cv2  # type: ignore
+        import numpy as np  # type: ignore
+    except Exception as e:
+        raise NotImplementedError("YOLO runtime deps missing (ultralytics, opencv). Install and retry.") from e
+
+    assert req.frames is not None and req.yolo is not None
+    det = YoloV8Detector(req.yolo.model_path, class_map=req.yolo.class_map, conf=req.yolo.conf)
+
+    frames = []
+    for idx, f in enumerate(req.frames):
+        t = _frames_to_time(req.meta.fps, f.t, idx)
+        img_bytes = base64.b64decode(f.image_b64)
+        buf = np.frombuffer(img_bytes, dtype=np.uint8)
+        img = cv2.imdecode(buf, cv2.IMREAD_COLOR)
+        detections = det.predict(img)
+        boxes = [Box(cls=d.cls, conf=d.conf, x1=d.x1, y1=d.y1, x2=d.x2, y2=d.y2) for d in detections]
+        frames.append((t, boxes))
+
+    ball, club, coverage = _build_trajs(frames, req.tracking)
+    metrics = compute_metrics(ball=ball, club=club, scale_m_per_px=req.meta.scale_m_per_px)
+    q = quality_score(num_points=min(len(ball), len(club)), fps=req.meta.fps, calibrated=req.meta.calibrated, coverage=coverage)
+    return InferResponse(shot_id=str(uuid4()), metrics=Metrics(**metrics), quality=q, meta=req.meta)
+
+def run_infer(req: InferRequest) -> InferResponse:
+    """Dispatch inference based on request mode."""
+    if req.mode == "detections":
+        return run_inference_from_detections(req)
+    elif req.mode == "frames_b64":
+        return run_inference_from_frames_b64(req)
+    else:
+        raise ValueError(f"unsupported mode: {req.mode}")

--- a/golfiq/server/services/quality_score.py
+++ b/golfiq/server/services/quality_score.py
@@ -1,7 +1,8 @@
-def quality_score(num_points: int, fps: float, calibrated: bool) -> str:
-    """Return a simple quality assessment string based on available data."""
-    if calibrated and num_points >= 10:
+def quality_score(num_points:int, fps:float, calibrated:bool, coverage:float|None=None) -> str:
+    # coverage = fraction of frames where a track was available (0..1)
+    cov = coverage if coverage is not None else 1.0
+    if calibrated and fps >= 60 and num_points >= 4 and cov >= 0.6:
         return "green"
-    if num_points >= 5:
+    if fps >= 30 and num_points >= 3 and cov >= 0.4:
         return "yellow"
     return "red"

--- a/golfiq/server/tests/test_infer_detections.py
+++ b/golfiq/server/tests/test_infer_detections.py
@@ -5,43 +5,40 @@ client = TestClient(app)
 
 def test_infer_with_detections():
     payload = {
-        "fps": 120.0,
-        "scale_m_per_px": 0.002,
-        "view": "DTL",
-        "calibrated": True,
         "mode": "detections",
         "detections": [
-            {"frame_idx": 0, "detections": [
+            {"t": -0.02, "dets": [
                 {"cls":"club_head","conf":0.9,"x1":100,"y1":500,"x2":120,"y2":520},
                 {"cls":"ball","conf":0.95,"x1":300,"y1":520,"x2":310,"y2":530}
             ]},
-            {"frame_idx": 1, "detections": [
+            {"t": -0.01, "dets": [
                 {"cls":"club_head","conf":0.9,"x1":120,"y1":498,"x2":140,"y2":518},
                 {"cls":"ball","conf":0.95,"x1":300,"y1":520,"x2":310,"y2":530}
             ]},
-            {"frame_idx": 2, "detections": [
+            {"t": 0.0, "dets": [
                 {"cls":"club_head","conf":0.9,"x1":150,"y1":490,"x2":170,"y2":510},
                 {"cls":"ball","conf":0.95,"x1":300,"y1":520,"x2":310,"y2":530}
             ]},
-            {"frame_idx": 3, "detections": [
+            {"t": 0.01, "dets": [
                 {"cls":"club_head","conf":0.9,"x1":300,"y1":520,"x2":320,"y2":540},
                 {"cls":"ball","conf":0.95,"x1":300,"y1":520,"x2":310,"y2":530}
             ]},
-            {"frame_idx": 4, "detections": [
+            {"t": 0.02, "dets": [
                 {"cls":"club_head","conf":0.9,"x1":320,"y1":522,"x2":340,"y2":542},
                 {"cls":"ball","conf":0.95,"x1":315,"y1":508,"x2":325,"y2":518}
             ]},
-            {"frame_idx": 5, "detections": [
+            {"t": 0.03, "dets": [
                 {"cls":"club_head","conf":0.9,"x1":340,"y1":524,"x2":360,"y2":544},
                 {"cls":"ball","conf":0.95,"x1":335,"y1":492,"x2":345,"y2":502}
             ]}
-        ]
+        ],
+        "meta": {"fps": 120.0, "scale_m_per_px": 0.002, "view": "DTL", "calibrated": True}
     }
     r = client.post("/infer", json=payload)
     assert r.status_code == 200
     data = r.json()
-    assert data["quality"] in ["green","yellow","red"]
+    assert data["quality"] in ["green", "yellow", "red"]
     m = data["metrics"]
-    for k in ["club_speed_mps","ball_speed_mps","launch_deg","carry_m"]:
+    for k in ["club_speed_mps", "ball_speed_mps", "launch_deg", "carry_m"]:
         assert k in m
         assert isinstance(m[k], (int, float))

--- a/golfiq/server/tests/test_infer_tracking_sortlite.py
+++ b/golfiq/server/tests/test_infer_tracking_sortlite.py
@@ -1,0 +1,36 @@
+from server.api.main import app
+from fastapi.testclient import TestClient
+
+def test_infer_detections_sortlite():
+    client = TestClient(app)
+    payload = {
+        "mode": "detections",
+        "detections": [
+            {"t": -0.02, "dets": [
+                {"cls":"club_head","conf":0.9,"x1":390,"y1":590,"x2":410,"y2":610},
+                {"cls":"ball","conf":0.9,"x1":500,"y1":600,"x2":502,"y2":602}
+            ]},
+            {"t": -0.01, "dets": [
+                {"cls":"club_head","conf":0.9,"x1":440,"y1":560,"x2":460,"y2":580},
+                {"cls":"ball","conf":0.9,"x1":500,"y1":600,"x2":502,"y2":602}
+            ]},
+            {"t": 0.00, "dets": [
+                {"cls":"club_head","conf":0.9,"x1":500,"y1":600,"x2":520,"y2":620},
+                {"cls":"ball","conf":0.9,"x1":500,"y1":600,"x2":502,"y2":602}
+            ]},
+            {"t": 0.01, "dets": [
+                {"cls":"club_head","conf":0.9,"x1":530,"y1":610,"x2":550,"y2":630},
+                {"cls":"ball","conf":0.9,"x1":515,"y1":590,"x2":517,"y2":592}
+            ]},
+            {"t": 0.02, "dets": [
+                {"cls":"club_head","conf":0.9,"x1":560,"y1":620,"x2":580,"y2":640},
+                {"cls":"ball","conf":0.9,"x1":530,"y1":580,"x2":532,"y2":582}
+            ]}
+        ],
+        "meta": {"fps": 120, "scale_m_per_px": 0.002, "calibrated": True, "view": "DTL"},
+        "tracking": {"mode":"sortlite", "iou_thr": 0.1}
+    }
+    r = client.post("/infer", json=payload)
+    assert r.status_code == 200
+    m = r.json()["metrics"]
+    assert m["club_speed_mps"] > 0 and m["ball_speed_mps"] > 0


### PR DESCRIPTION
## Summary
- add lightweight SortLite tracker for basic IoU-based association
- compute quality score with coverage awareness and expose via new schema
- update API, tests, and docs for new tracking flow

## Testing
- `python -m pytest cv-engine/tests server/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68c012f12ccc83268e1c942882564e6f