### PR TITLE
ci: install numpy for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install numpy
+      - name: Run tests
+        run: |
+          pytest


### PR DESCRIPTION
## Summary
- add minimal CI workflow that installs numpy before running tests

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'golfiq_cv')*


------
https://chatgpt.com/codex/tasks/task_e_68c046b857008326b0bcde981c46dad1