### PR TITLE
ci: install numpy+pytest and set PYTHONPATH

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # Ensure test deps
+          pip install numpy pytest
+          [ -d "golfiq/cv-engine" ] && pip install -e golfiq/cv-engine
+          pip install -r server/requirements.txt
+      - name: Run tests
+        env:
+          PYTHONPATH: "${{ github.workspace }}/golfiq/cv-engine:${{ github.workspace }}/golfiq/cv-engine/src"
+        run: |
+          pytest


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow running pytest
- install numpy and pytest, ensure cv-engine editable install, set PYTHONPATH

## Testing
- `PYTHONPATH=$PWD/golfiq/cv-engine:$PWD/golfiq/cv-engine/src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0692cca808326827a92ebef88c816