### PR TITLE
chore: repo governance (Dependabot, PR/Issue templates, CODEOWNERS)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners för allt innehåll
+* @Fatdevil

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,23 @@
+---
+name: Bug report
+about: Rapportera ett fel
+labels: bug
+---
+
+**Beskrivning**
+Vad är fel?
+
+**Repro**
+Steg för att återskapa:
+1. …
+2. …
+
+**Förväntat**
+Vad skulle hänt?
+
+**Loggar/skärmdumpar**
+(Lägg till om möjligt)
+
+**Miljö**
+- OS:
+- Version/branch:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Föreslå en förbättring
+labels: enhancement
+---
+
+**Problem / mål**
+Vad vill du uppnå?
+
+**Föreslagen lösning**
+Beskriv funktion/UX.
+
+**Alternativ**
+Eventuella alternativ.
+
+**Extra**
+Skisser, länkar, referenser.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Summary
+<!-- Kort beskrivning av ändringen. Varför behövs den? -->
+
+## Changes
+- [ ] ...
+
+## How to test
+1. ...
+2. ...
+
+## Screenshots / Logs
+<!-- Valfritt -->
+
+## Checklist
+- [ ] PR:en bygger lokalt
+- [ ] CI är grön
+- [ ] Inga breaking changes utan uppdaterad README/dokumentation

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/server"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    rebase-strategy: "auto"
+    labels: ["deps", "auto"]
+  - package-ecosystem: "pip"
+    directory: "/golfiq/cv-engine"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    rebase-strategy: "auto"
+    labels: ["deps", "auto"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels: ["deps", "actions", "auto"]


### PR DESCRIPTION
## Summary
- add Dependabot for pip and GitHub Actions
- add PR template
- add issue templates
- add CODEOWNERS defaulting to @Fatdevil

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68c06ff2206483269c2f10b55a5198f8