### PR TITLE
fix(server): add root health endpoint

### DIFF
--- a/server/api/health.py
+++ b/server/api/health.py
@@ -1,0 +1,6 @@
+from typing import Dict
+
+
+async def health() -> Dict[str, bool]:
+    """Simple health check endpoint."""
+    return {"ok": True}

--- a/server/api/main.py
+++ b/server/api/main.py
@@ -1,11 +1,13 @@
 from fastapi import FastAPI
 
+from .health import health as _health_handler
 from .routers import calibrate
 from .routers.coach import router as coach_router
 
 app = FastAPI()
 app.include_router(coach_router)
 app.include_router(calibrate.router)
+app.add_api_route("/health", _health_handler, methods=["GET"])
 
 
 @app.post("/analyze")


### PR DESCRIPTION
## Summary
- add a simple health check handler
- register `/health` on the FastAPI app

## Testing
- `pre-commit run --files server/api/main.py server/api/health.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'golfiq_cv')*


------
https://chatgpt.com/codex/tasks/task_e_68c1b2a8f8f08326ad5ae54d38467034