### PR TITLE
feat(metrics): add face-on metrics endpoint and tests

### DIFF
--- a/server/api/main.py
+++ b/server/api/main.py
@@ -1,3 +1,6 @@
+from pydantic import BaseModel
+from typing import List, Optional, Dict, Any
+from server.metrics.faceon import compute_faceon_metrics
 from fastapi import FastAPI
 
 from .health import health as _health_handler
@@ -14,3 +17,20 @@ app.add_api_route("/health", _health_handler, methods=["GET"])
 async def analyze():
     """Simple analyze endpoint returning status."""
     return {"status": "ok"}
+
+
+class FaceOnRequest(BaseModel):
+    frame_w: int
+    frame_h: int
+    detections: list
+    mm_per_px: float | None = None
+
+
+@app.post("/metrics/faceon")
+def metrics_faceon(req: FaceOnRequest):
+    return compute_faceon_metrics(
+        detections=req.detections,
+        frame_w=req.frame_w,
+        frame_h=req.frame_h,
+        mm_per_px=req.mm_per_px,
+    )

--- a/server/metrics/__init__.py
+++ b/server/metrics/__init__.py
@@ -1,0 +1,1 @@
+"""Metrics utilities for analyzing frames."""

--- a/server/metrics/faceon.py
+++ b/server/metrics/faceon.py
@@ -1,0 +1,62 @@
+from typing import List, Dict, Optional
+import math
+
+
+def _xyxy(det: Dict):
+    b = det.get("bbox") or det.get("xyxy")
+    if not b or len(b) != 4:
+        return None
+    x1, y1, x2, y2 = map(float, b)
+    if x2 < x1 or y2 < y1:
+        return None
+    return x1, y1, x2, y2
+
+
+def _is_person(det: Dict):
+    c = (det.get("cls") or det.get("class") or det.get("label") or "").lower()
+    cid = det.get("cls_id") if isinstance(det.get("cls_id"), int) else None
+    return c == "person" or cid == 0
+
+
+def compute_faceon_metrics(
+    detections: List[Dict],
+    frame_w: int,
+    frame_h: int,
+    mm_per_px: Optional[float] = None,
+) -> Dict:
+    """Heuristic MVP for face-on metrics.
+
+    - sway: distance from person center to frame center
+    - shoulder_tilt/shaft_lean: placeholders until pose/club data available
+    """
+    person = None
+    area_max = -1
+    for d in detections or []:
+        if not _is_person(d):
+            continue
+        box = _xyxy(d)
+        if not box:
+            continue
+        x1, y1, x2, y2 = box
+        a = (x2 - x1) * (y2 - y1)
+        if a > area_max:
+            area_max, person = a, box
+
+    sway_px = 0.0
+    if person:
+        x1, y1, x2, y2 = person
+        cx = (x1 + x2) / 2.0
+        sway_px = float(cx - (frame_w / 2.0))
+
+    sway_cm = None
+    if mm_per_px:
+        sway_cm = abs(sway_px) * (mm_per_px / 10.0)
+
+    return {
+        "sway_px": sway_px,
+        "sway_cm": None if sway_cm is None else float(sway_cm),
+        "shoulder_tilt_deg": 0.0,
+        "shaft_lean_deg": 0.0,
+        "frame": {"w": int(frame_w), "h": int(frame_h)},
+        "notes": None if person else "no-person-detected",
+    }

--- a/server/tests/test_metrics_faceon.py
+++ b/server/tests/test_metrics_faceon.py
@@ -1,0 +1,15 @@
+from server.metrics.faceon import compute_faceon_metrics
+
+
+def test_faceon_metrics_person_centered_cm():
+    dets = [{"cls": "person", "bbox": [45, 10, 155, 210]}]
+    out = compute_faceon_metrics(dets, frame_w=200, frame_h=240, mm_per_px=0.5)
+    assert "sway_px" in out and isinstance(out["sway_px"], float)
+    assert "sway_cm" in out and (out["sway_cm"] is None or isinstance(out["sway_cm"], float))
+    assert out["shoulder_tilt_deg"] == 0.0
+    assert out["shaft_lean_deg"] == 0.0
+
+
+def test_faceon_metrics_no_person():
+    out = compute_faceon_metrics([], frame_w=200, frame_h=240, mm_per_px=None)
+    assert out["notes"] == "no-person-detected"


### PR DESCRIPTION
## Summary
- add heuristic face-on metrics with sway calculation
- expose `/metrics/faceon` API endpoint and request model
- cover metrics helper with basic tests

## Testing
- `pytest server/tests/test_metrics_faceon.py -q`
- `pytest -q` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68c1c748a1dc8326a0fbbde2e9cd3f94