### PR TITLE
feat(app): show face-on metrics card

### DIFF
--- a/golfiq/app/src/components/MetricsCard.tsx
+++ b/golfiq/app/src/components/MetricsCard.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+type M = { sway_cm?: number|null, sway_px?: number, shoulder_tilt_deg?: number, shaft_lean_deg?: number };
+export default function MetricsCard({ m }: { m?: M }) {
+  if (!m) return null;
+  const row = (k:string,v?:number|null,suffix="") => (
+    <View style={styles.r} key={k}>
+      <Text style={styles.k}>{k}</Text>
+      <Text style={styles.v}>{v===null||v===undefined ? "—" : `${v.toFixed(1)}${suffix}`}</Text>
+    </View>
+  );
+  return (
+    <View style={styles.card}>
+      <Text style={styles.h}>Face-on metrics</Text>
+      {row("Sway", m.sway_cm ?? (m.sway_px ?? null), m.sway_cm!=null?" cm":" px")}
+      {row("Shoulder tilt", m.shoulder_tilt_deg, "°")}
+      {row("Shaft lean", m.shaft_lean_deg, "°")}
+    </View>
+  );
+}
+const styles = StyleSheet.create({
+  card:{ margin:12, padding:12, borderRadius:12, backgroundColor:"#0B0F14", borderWidth:1, borderColor:"#243041" },
+  h:{ fontWeight:"700", marginBottom:6, color:"#CFE3FF" },
+  r:{ flexDirection:"row", justifyContent:"space-between", paddingVertical:2 },
+  k:{ color:"#9AB0C6" }, v:{ color:"#E6F1FF", fontWeight:"600" }
+});

--- a/golfiq/app/src/lib/api.ts
+++ b/golfiq/app/src/lib/api.ts
@@ -43,3 +43,15 @@ export async function coachFeedback(mode: CoachMode, metrics: any, notes: string
   if(!r.ok) throw new Error('Coach failed');
   return await r.json(); // {text}
 }
+
+export async function metricsFaceOn(baseUrl: string, payload: {
+  frame_w: number; frame_h: number; detections: any[]; mm_per_px?: number|null;
+}) {
+  const r = await fetch(baseUrl + "/metrics/faceon", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (!r.ok) throw new Error("metricsFaceOn " + r.status);
+  return await r.json();
+}


### PR DESCRIPTION
## Summary
- add MetricsCard component for Face-on metrics
- integrate metricsFaceOn API and display metrics in camera infer screen

## Testing
- `pre-commit run --files golfiq/app/src/components/MetricsCard.tsx golfiq/app/src/lib/api.ts golfiq/app/src/screens/CameraInferScreen.tsx`
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68c1d13cfcd08326aa74d5e89914bad9