### PR TITLE
Ensure retention package is importable and fix PYTHONPATH

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,6 @@ jobs:
           pip install -r server/requirements.txt
       - name: Run tests
         env:
-          PYTHONPATH: "${{ github.workspace }}/golfiq/cv-engine:${{ github.workspace }}/golfiq/cv-engine/src"
+          PYTHONPATH: "${{ github.workspace }}:${{ github.workspace }}/golfiq/cv-engine:${{ github.workspace }}/golfiq/cv-engine/src"
         run: |
           pytest -q

--- a/server/retention/__init__.py
+++ b/server/retention/__init__.py
@@ -1,0 +1,1 @@
+# Package marker for retention services


### PR DESCRIPTION
## Summary
- add package marker for `server.retention`
- include repository root in CI `PYTHONPATH`

## Testing
- `pre-commit run --files .github/workflows/ci.yml server/retention/__init__.py`
- `PYTHONPATH="$PWD:$PWD/golfiq/cv-engine:$PWD/golfiq/cv-engine/src" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c1dbe18a848326a9f8524e99fcf335