### PR TITLE
test/packaging: add retention sweeper and document PYTHONPATH in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
           pip install -r server/requirements.txt
       - name: Run tests
         env:
+          # Ensure repo root on PYTHONPATH
           PYTHONPATH: "${{ github.workspace }}:${{ github.workspace }}/golfiq/cv-engine:${{ github.workspace }}/golfiq/cv-engine/src"
         run: |
           pytest -q

--- a/server/retention/sweeper.py
+++ b/server/retention/sweeper.py
@@ -1,0 +1,21 @@
+import os
+import time
+import pathlib
+from typing import Iterable, List
+
+
+def sweep_retention_once(dirs: Iterable[str], minutes: int) -> List[str]:
+    deleted = []
+    cutoff = time.time() - minutes * 60 if minutes > 0 else time.time()
+    for d in dirs or []:
+        p = pathlib.Path(d)
+        if not p.exists() or not p.is_dir():
+            continue
+        for f in p.rglob("*"):
+            if f.is_file() and f.stat().st_mtime < cutoff:
+                try:
+                    f.unlink(missing_ok=True)
+                    deleted.append(str(f))
+                except Exception:
+                    pass
+    return deleted


### PR DESCRIPTION
## Summary
- add sweeper module for retention package
- document repo root on PYTHONPATH in CI config

## Testing
- `pre-commit run --all-files --show-diff-on-failure`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68c1e0cf04dc8326be176a06e1885bb2