### PR TITLE
style: apply pre-commit/isort/black fixes to retention sweeper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
           pip install -r server/requirements.txt
       - name: Run tests
         env:
+          # Ensure repo root on PYTHONPATH
           PYTHONPATH: "${{ github.workspace }}:${{ github.workspace }}/golfiq/cv-engine:${{ github.workspace }}/golfiq/cv-engine/src"
         run: |
           pytest -q

--- a/server/retention/sweeper.py
+++ b/server/retention/sweeper.py
@@ -1,0 +1,20 @@
+import pathlib
+import time
+from typing import Iterable, List
+
+
+def sweep_retention_once(dirs: Iterable[str], minutes: int) -> List[str]:
+    deleted = []
+    cutoff = time.time() - minutes * 60 if minutes > 0 else time.time()
+    for d in dirs or []:
+        p = pathlib.Path(d)
+        if not p.exists() or not p.is_dir():
+            continue
+        for f in p.rglob("*"):
+            if f.is_file() and f.stat().st_mtime < cutoff:
+                try:
+                    f.unlink(missing_ok=True)
+                    deleted.append(str(f))
+                except Exception:
+                    pass
+    return deleted


### PR DESCRIPTION
## Summary
- run isort and black on retention sweeper
- remove unused imports and satisfy pre-commit

## Testing
- `pre-commit run --files server/retention/sweeper.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'golfiq_cv')*

------
https://chatgpt.com/codex/tasks/task_e_68c1e39ae1048326b189917959b9d5b6