### PR TITLE
ci(release): tag-triggered release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+on:
+  push:
+    tags: ["v*.*.*"]
+jobs:
+  build-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.12' }
+
+      - name: Prepare server bundle
+        run: |
+          mkdir -p dist/server
+          cp -r server dist/server/
+          cp README.md dist/server/ 2>/dev/null || true
+          find dist/server -name "__pycache__" -type d -prune -exec rm -rf {} +
+          cd dist && zip -r server.zip server
+
+      - name: Prepare app bundle (source only)
+        run: |
+          mkdir -p dist/app
+          cp -r golfiq/app dist/app/
+          cp README.md dist/app/ 2>/dev/null || true
+          cd dist && zip -r app.zip app
+
+      - name: Checksums
+        run: cd dist && sha256sum server.zip app.zip > checksums.txt
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/server.zip
+            dist/app.zip
+            dist/checksums.txt
+        env:
+          GITHUB_TOKEN: ${{ secrets.CODEX_PAT || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- release workflow triggered on tags like v*.*.*
- upload server/app bundles and checksum file

## Testing
- `pre-commit run --files .github/workflows/release.yml`
- `pytest -q` *(fails: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68c1e7ba260483268de2dea4213e31eb