### PR TITLE
chore: add Codex Runner (task executor)

### DIFF
--- a/.github/workflows/codex-runner.yml
+++ b/.github/workflows/codex-runner.yml
@@ -1,5 +1,4 @@
 name: Codex Runner
-
 on:
   workflow_dispatch:
     inputs:
@@ -7,40 +6,32 @@ on:
         description: "Bash script to run against this repo (multi-line)."
         required: true
         type: string
-
 permissions:
   contents: write
   pull-requests: write
-
 jobs:
   run:
     runs-on: ubuntu-latest
     env:
-      PAT: ${{ secrets.CODEX_PAT }}         # ← din PAT som repo-secret
+      PAT: ${{ secrets.CODEX_PAT }}
       REPO: ${{ github.repository }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
-
       - name: Tooling
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y jq
-
-      - name: Prepare git with PAT (so pushes trigger CI)
+        run: sudo apt-get update -y && sudo apt-get install -y jq
+      - name: Prepare git with PAT
         run: |
           git config user.name "codex-bot"
           git config user.email "bot@users.noreply.github.com"
           if [ -n "${PAT}" ]; then
             git remote set-url origin "https://x-access-token:${PAT}@github.com/${REPO}.git"
           fi
-
       - name: Run task
         shell: bash
         run: |
           cat > /tmp/task.sh <<'TASK'
-${{ inputs.task }}
-TASK
+          ${{ inputs.task }}
+          TASK
           chmod +x /tmp/task.sh
           /bin/bash -eo pipefail /tmp/task.sh


### PR DESCRIPTION
## Summary
- add Codex Runner GitHub Action workflow for executing provided bash tasks

## Testing
- `pre-commit run --files .github/workflows/codex-runner.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c2efc76d9c8326b60946715228ddf7