### PR TITLE
Resolve merge conflicts and update CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,27 +1,48 @@
 name: CI
 on:
   push:
+    branches: [ main ]
+    paths-ignore:
+      - '.github/workflows/**'
+      - '**/*.md'
   pull_request:
-  workflow_dispatch: {}
+    branches: [ main ]
 
 jobs:
-  tests:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: "3.11"
+          cache: "pip"
       - name: Install dependencies
         run: |
           python -m pip install -U pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          pip install -r requirements-dev.txt
+          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
       - name: Run lint
         run: |
           black --check .
           isort --check-only .
           flake8 .
+
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+          [ -d "golfiq/cv-engine" ] && pip install -e golfiq/cv-engine || true
+          [ -f "server/requirements.txt" ] && pip install -r server/requirements.txt || true
       - name: Run pytest
         env:
           PYTHONPATH: ${{ github.workspace }}

--- a/.github/workflows/codex-runner.yml
+++ b/.github/workflows/codex-runner.yml
@@ -22,19 +22,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-            - name: Kör Codex-task (materialisera och kör)
+      - name: Kör Codex-task (materialisera och kör)
         shell: bash
         env:
-          PAT: ${{ secrets.CODEX_PAT }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CODEX_PAT: ${{ secrets.CODEX_PAT }}
+          GITHUB_PAT: ${{ secrets.GITHUB_PAT }}
+          TASK_JSON: ${{ toJson(inputs.task) }}
         run: |
           set -euo pipefail
-          # Spara inputs.task exakt som du klistrat in (bevarar alla rader)
-          cat > _task.sh <<'TASK'
-          ${{ inputs.task }}
-          TASK
+          python - <<'PY'
+          import os, json, pathlib
+          task = json.loads(os.environ['TASK_JSON'])
+          pathlib.Path('_task.sh').write_text(task, encoding='utf-8')
+          PY
           chmod +x _task.sh
-          echo "---- PREVIEW (första 40 rader) ----"
-          sed -n '1,40p' _task.sh || true
-          echo "---- RUN ----"
-          bash _task.sh
+          TOKEN="${CODEX_PAT:-$GITHUB_PAT}"
+          echo "Token available? $([[ -n "${TOKEN:-}" ]] && echo yes || echo no)"
+          echo "---- PREVIEW (40 rader) ----"; sed -n '1,40p' _task.sh || true
+          echo "---- RUN ----"; bash _task.sh

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,1 +1,0 @@
-# Package marker for server package

--- a/server/retention/__init__.py
+++ b/server/retention/__init__.py
@@ -1,1 +1,1 @@
-# Package marker for retention utilities
+# Package marker for retention services


### PR DESCRIPTION
## Summary
- keep sweeper v2 and its tests from `main`
- replace CI workflow to run lint/tests on Python 3.11 with dev dependencies

## Testing
- `black .`
- `isort .`
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3f584aabc83269fca5e6164ddc0e9