### PR TITLE
feat: add face-on metrics endpoint

### DIFF
--- a/server/api/main.py
+++ b/server/api/main.py
@@ -7,7 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from server.retention.sweeper import sweep_retention_once
 
 from .health import health as _health_handler
-from .routers import calibrate
+from .routers import calibrate, metrics
 from .routers.coach import router as coach_router
 
 
@@ -41,6 +41,7 @@ api_dep = _api_key_dependency()
 
 app.include_router(coach_router)
 app.include_router(calibrate.router)
+app.include_router(metrics.router)
 app.add_api_route("/health", _health_handler, methods=["GET"])
 
 

--- a/server/api/routers/metrics.py
+++ b/server/api/routers/metrics.py
@@ -1,0 +1,26 @@
+from typing import Dict, List, Optional
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from server.metrics.faceon import compute_faceon_metrics
+
+
+class FaceOnMetricsRequest(BaseModel):
+    frame_w: int
+    frame_h: int
+    detections: List[Dict]
+    mm_per_px: Optional[float] = None
+
+
+router = APIRouter()
+
+
+@router.post("/metrics/faceon")
+def metrics_faceon(payload: FaceOnMetricsRequest):
+    return compute_faceon_metrics(
+        payload.detections,
+        frame_w=payload.frame_w,
+        frame_h=payload.frame_h,
+        mm_per_px=payload.mm_per_px,
+    )

--- a/server/metrics/faceon.py
+++ b/server/metrics/faceon.py
@@ -1,0 +1,61 @@
+from typing import Dict, List, Optional
+
+
+def _xyxy(det: Dict):
+    b = det.get("bbox") or det.get("xyxy")
+    if not b or len(b) != 4:
+        return None
+    x1, y1, x2, y2 = map(float, b)
+    if x2 < x1 or y2 < y1:
+        return None
+    return x1, y1, x2, y2
+
+
+def _is_person(det: Dict) -> bool:
+    c = (det.get("cls") or det.get("class") or det.get("label") or "").lower()
+    cid = det.get("cls_id") if isinstance(det.get("cls_id"), int) else None
+    return c == "person" or cid == 0
+
+
+def compute_faceon_metrics(
+    detections: List[Dict],
+    frame_w: int,
+    frame_h: int,
+    mm_per_px: Optional[float] = None,
+) -> Dict:
+    """Heuristic MVP for face-on metrics.
+
+    - sway: distance from person center to frame center
+    - shoulder_tilt/shaft_lean: placeholders until pose/club data available
+    """
+    person = None
+    area_max = -1
+    for d in detections or []:
+        if not _is_person(d):
+            continue
+        box = _xyxy(d)
+        if not box:
+            continue
+        x1, y1, x2, y2 = box
+        a = (x2 - x1) * (y2 - y1)
+        if a > area_max:
+            area_max, person = a, box
+
+    sway_px = 0.0
+    if person:
+        x1, _, x2, _ = person
+        cx = (x1 + x2) / 2.0
+        sway_px = float(cx - (frame_w / 2.0))
+
+    sway_cm = None
+    if mm_per_px:
+        sway_cm = abs(sway_px) * (mm_per_px / 10.0)
+
+    return {
+        "sway_px": sway_px,
+        "sway_cm": None if sway_cm is None else float(sway_cm),
+        "shoulder_tilt_deg": 0.0,
+        "shaft_lean_deg": 0.0,
+        "frame": {"w": int(frame_w), "h": int(frame_h)},
+        "notes": None if person else "no-person-detected",
+    }


### PR DESCRIPTION
## Summary
- implement heuristic face-on metrics computation
- expose POST /metrics/faceon endpoint

## Testing
- `isort .`
- `flake8 .`
- `PYTHONPATH=$PWD pytest server/tests/test_metrics_faceon.py -q`
- `PYTHONPATH=$PWD pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4247163e8832695b5f1700bd3c11d