### PR TITLE
ci: auto-merge green PRs

### DIFF
--- a/.github/workflows/auto-merge-green.yml
+++ b/.github/workflows/auto-merge-green.yml
@@ -1,0 +1,67 @@
+name: Auto Merge Green PRs
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: "*/30 * * * *"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Merge green PRs
+        env:
+          CODEX_PAT: ${{ secrets.CODEX_PAT }}
+          GITHUB_PAT: ${{ secrets.GITHUB_PAT }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json, os, urllib.request
+
+          repo=os.environ["REPO"]
+          token=os.environ.get("CODEX_PAT") or os.environ.get("GITHUB_PAT")
+          headers={"Authorization":f"token {token}",
+                   "Accept":"application/vnd.github+json",
+                   "User-Agent":"auto-merge-script"}
+
+          def gh(url, method="GET", data=None):
+              if data is not None:
+                  data=json.dumps(data).encode()
+              req=urllib.request.Request(url, data=data, headers=headers, method=method)
+              with urllib.request.urlopen(req) as resp:
+                  if resp.status==204:
+                      return {}
+                  return json.load(resp)
+
+          prs=gh(f"https://api.github.com/repos/{repo}/pulls?state=open&per_page=100")
+          for pr in prs:
+              num=pr["number"]
+              if pr["draft"] or pr["head"]["repo"]["fork"]:
+                  continue
+              detail=gh(f"https://api.github.com/repos/{repo}/pulls/{num}")
+              if detail.get("mergeable_state")=="dirty" or not detail.get("mergeable"):
+                  continue
+              sha=pr["head"]["sha"]
+              status=gh(f"https://api.github.com/repos/{repo}/commits/{sha}/status").get("state")
+              if status != "success":
+                  continue
+              reviews=gh(f"https://api.github.com/repos/{repo}/pulls/{num}/reviews")
+              if any(r["state"]=="CHANGES_REQUESTED" for r in reviews):
+                  continue
+              gh(f"https://api.github.com/repos/{repo}/pulls/{num}/merge",
+                 method="PUT", data={"merge_method":"squash"})
+              gh(f"https://api.github.com/repos/{repo}/git/refs/heads/{pr['head']['ref']}",
+                 method="DELETE")
+              gh(f"https://api.github.com/repos/{repo}/issues/{num}/comments",
+                 method="POST", data={"body":"Auto-merged by control-plane (all checks green)"})
+              print(f"merged #{num}")
+          PY


### PR DESCRIPTION
## Summary
- add workflow to auto-merge green pull requests

## Testing
- `pre-commit run --files .github/workflows/auto-merge-green.yml`
- `pytest -q`
- `curl -s -H "Authorization: token $TOKEN" -X POST https://api.github.com/repos/Fatdevil/GolfIQ-YOLO/actions/workflows/auto-merge-green.yml/dispatches -d '{"ref":"main"}'`


------
https://chatgpt.com/codex/tasks/task_e_68c445163ca4832692cc41b7612559fe