### PR TITLE
feat(cv): cv_engine skeleton (YoloV8Detector + ImpactDetector, mockable) + tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,6 @@ Project repository.
    - **macOS/Linux:** `bash scripts/run_staging.sh`
 3) Testa: `GET http://localhost:8000/health` → `{\"status\":\"ok\", ...}`
    Om `API_KEY` i `.env` är satt måste klienter skicka header `x-api-key: <värdet>` (ej nödvändigt för /health).
+
+### cv_engine (mock)
+Run: `GOLFIQ_MOCK=1 python -m cv_engine.cli --mock-frames 5`

--- a/cv_engine/__init__.py
+++ b/cv_engine/__init__.py
@@ -1,0 +1,1 @@
+"""cv_engine package."""

--- a/cv_engine/cli.py
+++ b/cv_engine/cli.py
@@ -1,0 +1,20 @@
+import argparse
+import os
+
+import numpy as np
+
+from .impact.detector import ImpactDetector
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--mock-frames", type=int, default=5, help="antal dummy-frames")
+    args = ap.parse_args()
+    os.environ.setdefault("GOLFIQ_MOCK", "1")
+    frames = [np.zeros((720, 1280, 3), dtype=np.uint8) for _ in range(args.mock_frames)]
+    ev = ImpactDetector().run(frames)
+    print({"events": [e.frame_index for e in ev]})
+
+
+if __name__ == "__main__":
+    main()

--- a/cv_engine/impact/detector.py
+++ b/cv_engine/impact/detector.py
@@ -1,0 +1,33 @@
+import os
+from typing import Iterable, List
+
+import numpy as np
+
+from ..inference.yolo8 import YoloV8Detector
+from ..tracking.factory import get_tracker
+from ..types import Box, ImpactEvent
+
+
+def _overlap(a: Box, b: Box) -> bool:
+    return not (a.x2 < b.x1 or b.x2 < a.x1 or a.y2 < b.y1 or b.y2 < a.y1)
+
+
+class ImpactDetector:
+    """
+    Enkel heuristik för mock-läge:
+      - impact = första frame där ball- och club-boxar överlappar
+    """
+
+    def __init__(self, detector: YoloV8Detector | None = None):
+        self.detector = detector or YoloV8Detector()
+        self.tracker = get_tracker()
+        self.mock = os.getenv("GOLFIQ_MOCK", "0") == "1"
+
+    def run(self, frames: Iterable["np.ndarray"]) -> List[ImpactEvent]:
+        for idx, frame in enumerate(frames):
+            boxes = self.detector.run(frame)
+            balls = [b for b in boxes if b.label == "ball"]
+            clubs = [b for b in boxes if b.label == "club"]
+            if any(_overlap(b, c) for b in balls for c in clubs):
+                return [ImpactEvent(frame_index=idx, confidence=0.9)]
+        return []

--- a/cv_engine/inference/yolo8.py
+++ b/cv_engine/inference/yolo8.py
@@ -1,0 +1,59 @@
+import os
+from typing import List
+
+import numpy as np
+
+from ..types import Box
+
+
+class YoloV8Detector:
+    """
+    Minimalt interface:
+      - mock-läge (GOLFIQ_MOCK=1) ger deterministiska boxar (ball + club)
+      - real-läge försöker ladda Ultralytics YOLO men faller snällt tillbaka till mock
+    """
+
+    def __init__(self, weight_path: str | None = None, device: str = "cpu"):
+        self.mock = os.getenv("GOLFIQ_MOCK", "0") == "1"
+        self.model = None
+        if not self.mock and weight_path:
+            try:
+                from ultralytics import YOLO  # type: ignore
+
+                self.model = YOLO(weight_path)
+            except Exception:
+                self.mock = True
+
+    def run(self, image: "np.ndarray") -> List[Box]:
+        h, w = image.shape[:2]
+        if self.mock or self.model is None:
+            # deterministiska boxar: en boll och en klubba
+            return [
+                Box(
+                    int(w * 0.45),
+                    int(h * 0.48),
+                    int(w * 0.52),
+                    int(h * 0.55),
+                    "ball",
+                    0.95,
+                ),
+                Box(
+                    int(w * 0.30),
+                    int(h * 0.60),
+                    int(w * 0.38),
+                    int(h * 0.80),
+                    "club",
+                    0.92,
+                ),
+            ]
+        # (real-läge – håll lätt och utan tunga beroenden i tests)
+        results = self.model.predict(image, device="cpu", verbose=False)  # type: ignore
+        boxes: List[Box] = []
+        for r in results:
+            for b in r.boxes:
+                x1, y1, x2, y2 = map(int, b.xyxy[0].tolist())
+                cls = int(b.cls[0])
+                score = float(b.conf[0])
+                label = "ball" if cls == 0 else "object"
+                boxes.append(Box(x1, y1, x2, y2, label, score))
+        return boxes

--- a/cv_engine/tests/test_impact_mock.py
+++ b/cv_engine/tests/test_impact_mock.py
@@ -1,0 +1,27 @@
+import os
+
+import numpy as np
+
+from cv_engine.impact.detector import ImpactDetector
+from cv_engine.types import Box
+
+
+class _FakeDet:
+    def __init__(self):
+        self.calls = 0
+
+    def run(self, _img):
+        self.calls += 1
+        if self.calls < 2:  # ingen overlap i frame 0
+            return [Box(0, 0, 10, 10, "ball", 1.0), Box(20, 20, 30, 30, "club", 1.0)]
+        return [
+            Box(0, 0, 20, 20, "ball", 1.0),
+            Box(10, 10, 30, 30, "club", 1.0),
+        ]  # overlap i frame 1
+
+
+def test_impact_emits_event_on_overlap():
+    os.environ["GOLFIQ_MOCK"] = "1"
+    frames = [np.zeros((64, 64, 3), dtype=np.uint8) for _ in range(3)]
+    ev = ImpactDetector(detector=_FakeDet()).run(frames)
+    assert len(ev) == 1 and ev[0].frame_index == 1

--- a/cv_engine/tests/test_integration_mock.py
+++ b/cv_engine/tests/test_integration_mock.py
@@ -1,0 +1,12 @@
+import os
+
+import numpy as np
+
+from cv_engine.impact.detector import ImpactDetector
+
+
+def test_integration_pipeline_mock():
+    os.environ["GOLFIQ_MOCK"] = "1"
+    frames = [np.zeros((64, 64, 3), dtype=np.uint8) for _ in range(3)]
+    # Heuristiken kan ge 0 eller 1 event beroende på overlap; det viktiga: inga exceptions.
+    ImpactDetector().run(frames)

--- a/cv_engine/tests/test_yolo8_mock.py
+++ b/cv_engine/tests/test_yolo8_mock.py
@@ -1,0 +1,13 @@
+import os
+
+import numpy as np
+
+from cv_engine.inference.yolo8 import YoloV8Detector
+
+
+def test_yolo8_mock_returns_boxes():
+    os.environ["GOLFIQ_MOCK"] = "1"
+    img = np.zeros((100, 100, 3), dtype=np.uint8)
+    boxes = YoloV8Detector().run(img)
+    labels = sorted([b.label for b in boxes])
+    assert labels == ["ball", "club"]

--- a/cv_engine/tracking/factory.py
+++ b/cv_engine/tracking/factory.py
@@ -1,0 +1,15 @@
+from typing import List, Tuple
+
+from ..types import Box
+
+
+class _IdentityTracker:
+    """Minimal stub: ger stabila track-ids 1..N per frame."""
+
+    def update(self, boxes: List[Box]) -> List[Tuple[int, Box]]:
+        return list(zip(range(1, len(boxes) + 1), boxes))
+
+
+def get_tracker(name: str = "stub", **kwargs) -> _IdentityTracker:
+    # framtida: byt till ByteTrack/DeepSort; nu: stub för tester
+    return _IdentityTracker()

--- a/cv_engine/types.py
+++ b/cv_engine/types.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+from typing import Tuple
+
+
+@dataclass(frozen=True)
+class Box:
+    x1: int
+    y1: int
+    x2: int
+    y2: int
+    label: str = "object"
+    score: float = 1.0
+
+    def center(self) -> Tuple[float, float]:
+        return ((self.x1 + self.x2) / 2, (self.y1 + self.y2) / 2)
+
+
+@dataclass(frozen=True)
+class ImpactEvent:
+    frame_index: int
+    confidence: float = 0.9


### PR DESCRIPTION
Labels: codex

✅ CV-skelett klart (mock-läge).
- YoloV8Detector interface + fallback till mock
- ImpactDetector med enkel overlap-heuristik
- Tracking-stub via factory
- Snabba tester utan weights
Command: `GOLFIQ_MOCK=1 python -m cv_engine.cli --mock-frames 5`


------
https://chatgpt.com/codex/tasks/task_e_68c5c86aff2883268769b8a339d6d1d7