### PR TITLE
feat(cv+server): detector-driven pipeline + /cv/mock/analyze mode=detector (mock motion) + tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,10 @@ curl -X POST http://localhost:8000/cv/mock/analyze \
   -H "Content-Type: application/json" \
   -d '{"frames":10,"fps":120,"ref_len_m":1.0,"ref_len_px":100.0,"ball_dx_px":2,"ball_dy_px":-1}'
 ```
+
+You can switch the mock analysis to the detector-driven pipeline:
+```
+curl -X POST http://localhost:8000/cv/mock/analyze \
+  -H "Content-Type: application/json" \
+  -d '{"mode":"detector","frames":10,"fps":120,"ref_len_m":1.0,"ref_len_px":100,"ball_dx_px":2,"ball_dy_px":-1}'
+```

--- a/cv_engine/inference/yolo8.py
+++ b/cv_engine/inference/yolo8.py
@@ -34,11 +34,17 @@ class YoloV8Detector:
         self.calls += 1
         k = self.calls - 1
         if self.mock or self.model is None:
-            bx1, by1, bx2, by2 = int(w * 0.45), int(h * 0.48), int(w * 0.52), int(
-                h * 0.55
+            bx1, by1, bx2, by2 = (
+                int(w * 0.45),
+                int(h * 0.48),
+                int(w * 0.52),
+                int(h * 0.55),
             )
-            cx1, cy1, cx2, cy2 = int(w * 0.30), int(h * 0.60), int(w * 0.38), int(
-                h * 0.80
+            cx1, cy1, cx2, cy2 = (
+                int(w * 0.30),
+                int(h * 0.60),
+                int(w * 0.38),
+                int(h * 0.80),
             )
             bx1 += int(self.dx_ball * k)
             bx2 += int(self.dx_ball * k)

--- a/cv_engine/inference/yolo8.py
+++ b/cv_engine/inference/yolo8.py
@@ -16,6 +16,11 @@ class YoloV8Detector:
     def __init__(self, weight_path: str | None = None, device: str = "cpu"):
         self.mock = os.getenv("GOLFIQ_MOCK", "0") == "1"
         self.model = None
+        self.calls = 0
+        self.dx_ball = float(os.getenv("GOLFIQ_MOTION_DX_BALL", "2.0"))
+        self.dy_ball = float(os.getenv("GOLFIQ_MOTION_DY_BALL", "-1.0"))
+        self.dx_club = float(os.getenv("GOLFIQ_MOTION_DX_CLUB", "1.5"))
+        self.dy_club = float(os.getenv("GOLFIQ_MOTION_DY_CLUB", "0.0"))
         if not self.mock and weight_path:
             try:
                 from ultralytics import YOLO  # type: ignore
@@ -26,25 +31,34 @@ class YoloV8Detector:
 
     def run(self, image: "np.ndarray") -> List[Box]:
         h, w = image.shape[:2]
+        self.calls += 1
+        k = self.calls - 1
         if self.mock or self.model is None:
-            # deterministiska boxar: en boll och en klubba
+            bx1, by1, bx2, by2 = int(w * 0.45), int(h * 0.48), int(w * 0.52), int(
+                h * 0.55
+            )
+            cx1, cy1, cx2, cy2 = int(w * 0.30), int(h * 0.60), int(w * 0.38), int(
+                h * 0.80
+            )
+            bx1 += int(self.dx_ball * k)
+            bx2 += int(self.dx_ball * k)
+            by1 += int(self.dy_ball * k)
+            by2 += int(self.dy_ball * k)
+            cx1 += int(self.dx_club * k)
+            cx2 += int(self.dx_club * k)
+            cy1 += int(self.dy_club * k)
+            cy2 += int(self.dy_club * k)
+            bx1 = max(0, min(bx1, w - 1))
+            bx2 = max(0, min(bx2, w - 1))
+            by1 = max(0, min(by1, h - 1))
+            by2 = max(0, min(by2, h - 1))
+            cx1 = max(0, min(cx1, w - 1))
+            cx2 = max(0, min(cx2, w - 1))
+            cy1 = max(0, min(cy1, h - 1))
+            cy2 = max(0, min(cy2, h - 1))
             return [
-                Box(
-                    int(w * 0.45),
-                    int(h * 0.48),
-                    int(w * 0.52),
-                    int(h * 0.55),
-                    "ball",
-                    0.95,
-                ),
-                Box(
-                    int(w * 0.30),
-                    int(h * 0.60),
-                    int(w * 0.38),
-                    int(h * 0.80),
-                    "club",
-                    0.92,
-                ),
+                Box(bx1, by1, bx2, by2, "ball", 0.95),
+                Box(cx1, cy1, cx2, cy2, "club", 0.92),
             ]
         # (real-läge – håll lätt och utan tunga beroenden i tests)
         results = self.model.predict(image, device="cpu", verbose=False)  # type: ignore

--- a/cv_engine/pipeline/analyze.py
+++ b/cv_engine/pipeline/analyze.py
@@ -6,6 +6,7 @@ from ..impact.detector import ImpactDetector
 from ..metrics.kinematics import CalibrationParams
 from ..calibration.simple import measure_from_tracks, as_dict
 
+
 def _centers_by_label(boxes) -> Dict[str, List[Tuple[float, float]]]:
     out: Dict[str, List[Tuple[float, float]]] = {"ball": [], "club": []}
     for b in boxes:
@@ -13,7 +14,10 @@ def _centers_by_label(boxes) -> Dict[str, List[Tuple[float, float]]]:
             out[b.label].append(b.center())
     return {k: ([v[0]] if v else []) for k, v in out.items()}
 
-def analyze_frames(frames: Iterable["np.ndarray"], calib: CalibrationParams) -> Dict[str, Any]:
+
+def analyze_frames(
+    frames: Iterable["np.ndarray"], calib: CalibrationParams
+) -> Dict[str, Any]:
     det = YoloV8Detector()
     ball_track: List[Tuple[float, float]] = []
     club_track: List[Tuple[float, float]] = []
@@ -27,8 +31,13 @@ def analyze_frames(frames: Iterable["np.ndarray"], calib: CalibrationParams) -> 
     events = [e.frame_index for e in ImpactDetector().run(frames)]
 
     if len(ball_track) < 2 or len(club_track) < 2:
-        metrics = {"ball_speed_mps": 0.0, "ball_speed_mph": 0.0,
-                   "club_speed_mps": 0.0, "launch_deg": 0.0, "carry_m": 0.0}
+        metrics = {
+            "ball_speed_mps": 0.0,
+            "ball_speed_mph": 0.0,
+            "club_speed_mps": 0.0,
+            "launch_deg": 0.0,
+            "carry_m": 0.0,
+        }
     else:
         m = measure_from_tracks(ball_track, club_track, calib)
         metrics = as_dict(m)

--- a/cv_engine/pipeline/analyze.py
+++ b/cv_engine/pipeline/analyze.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+from typing import Iterable, Dict, Any, List, Tuple
+import numpy as np
+from ..inference.yolo8 import YoloV8Detector
+from ..impact.detector import ImpactDetector
+from ..metrics.kinematics import CalibrationParams
+from ..calibration.simple import measure_from_tracks, as_dict
+
+def _centers_by_label(boxes) -> Dict[str, List[Tuple[float, float]]]:
+    out: Dict[str, List[Tuple[float, float]]] = {"ball": [], "club": []}
+    for b in boxes:
+        if b.label in out:
+            out[b.label].append(b.center())
+    return {k: ([v[0]] if v else []) for k, v in out.items()}
+
+def analyze_frames(frames: Iterable["np.ndarray"], calib: CalibrationParams) -> Dict[str, Any]:
+    det = YoloV8Detector()
+    ball_track: List[Tuple[float, float]] = []
+    club_track: List[Tuple[float, float]] = []
+    for fr in frames:
+        centers = _centers_by_label(det.run(fr))
+        if centers["ball"]:
+            ball_track.append(centers["ball"][0])
+        if centers["club"]:
+            club_track.append(centers["club"][0])
+
+    events = [e.frame_index for e in ImpactDetector().run(frames)]
+
+    if len(ball_track) < 2 or len(club_track) < 2:
+        metrics = {"ball_speed_mps": 0.0, "ball_speed_mph": 0.0,
+                   "club_speed_mps": 0.0, "launch_deg": 0.0, "carry_m": 0.0}
+    else:
+        m = measure_from_tracks(ball_track, club_track, calib)
+        metrics = as_dict(m)
+    return {"events": events, "metrics": metrics}

--- a/cv_engine/tests/test_pipeline_mock.py
+++ b/cv_engine/tests/test_pipeline_mock.py
@@ -3,6 +3,7 @@ import numpy as np
 from cv_engine.pipeline.analyze import analyze_frames
 from cv_engine.metrics.kinematics import CalibrationParams
 
+
 def test_pipeline_detector_mock_motion_produces_metrics():
     os.environ["GOLFIQ_MOCK"] = "1"
     os.environ["GOLFIQ_MOTION_DX_BALL"] = "2.0"
@@ -10,7 +11,7 @@ def test_pipeline_detector_mock_motion_produces_metrics():
     os.environ["GOLFIQ_MOTION_DX_CLUB"] = "1.5"
     os.environ["GOLFIQ_MOTION_DY_CLUB"] = "0.0"
 
-    frames = [np.zeros((64,64,3), dtype=np.uint8) for _ in range(10)]
+    frames = [np.zeros((64, 64, 3), dtype=np.uint8) for _ in range(10)]
     calib = CalibrationParams.from_reference(1.0, 100.0, 120.0)
     out = analyze_frames(frames, calib)
     m = out["metrics"]

--- a/cv_engine/tests/test_pipeline_mock.py
+++ b/cv_engine/tests/test_pipeline_mock.py
@@ -1,0 +1,19 @@
+import os
+import numpy as np
+from cv_engine.pipeline.analyze import analyze_frames
+from cv_engine.metrics.kinematics import CalibrationParams
+
+def test_pipeline_detector_mock_motion_produces_metrics():
+    os.environ["GOLFIQ_MOCK"] = "1"
+    os.environ["GOLFIQ_MOTION_DX_BALL"] = "2.0"
+    os.environ["GOLFIQ_MOTION_DY_BALL"] = "-1.0"
+    os.environ["GOLFIQ_MOTION_DX_CLUB"] = "1.5"
+    os.environ["GOLFIQ_MOTION_DY_CLUB"] = "0.0"
+
+    frames = [np.zeros((64,64,3), dtype=np.uint8) for _ in range(10)]
+    calib = CalibrationParams.from_reference(1.0, 100.0, 120.0)
+    out = analyze_frames(frames, calib)
+    m = out["metrics"]
+    assert abs(m["ball_speed_mps"] - 2.68) < 0.2
+    assert 5.7 <= m["ball_speed_mph"] <= 6.3
+    assert 25.0 <= m["launch_deg"] <= 28.5

--- a/server/routes/cv_mock.py
+++ b/server/routes/cv_mock.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, Field
 from cv_engine.calibration.simple import as_dict, measure_from_tracks
 from cv_engine.impact.detector import ImpactDetector
 from cv_engine.metrics.kinematics import CalibrationParams
+from cv_engine.pipeline.analyze import analyze_frames
 
 router = APIRouter(prefix="/cv/mock", tags=["cv-mock"])
 
@@ -22,6 +23,7 @@ class AnalyzeRequest(BaseModel):
     ball_dy_px: float = -1.0  # uppåt i bild (y minskar per frame)
     club_dx_px: float = 1.5
     club_dy_px: float = 0.0
+    mode: str = "tracks"  # "tracks" | "detector"
 
 
 class AnalyzeResponse(BaseModel):
@@ -31,19 +33,23 @@ class AnalyzeResponse(BaseModel):
 
 @router.post("/analyze", response_model=AnalyzeResponse)
 def analyze(req: AnalyzeRequest):
-    # Slå på mock-läge för CV-motorn
     os.environ.setdefault("GOLFIQ_MOCK", "1")
-
-    # 1) Kör ImpactDetector på dummy-frames (snabbt, bara demo)
     frames = [np.zeros((64, 64, 3), dtype=np.uint8) for _ in range(req.frames)]
-    events = [e.frame_index for e in ImpactDetector().run(frames)]
 
-    # 2) Syntetiska tracks (px) för mätmotor (deterministiskt)
-    #    Notera: y ökar nedåt i bild ⇒ fysikens dy inverteras i kinematik-modulen
+    if req.mode == "detector":
+        os.environ["GOLFIQ_MOTION_DX_BALL"] = str(req.ball_dx_px)
+        os.environ["GOLFIQ_MOTION_DY_BALL"] = str(req.ball_dy_px)
+        os.environ["GOLFIQ_MOTION_DX_CLUB"] = str(req.club_dx_px)
+        os.environ["GOLFIQ_MOTION_DY_CLUB"] = str(req.club_dy_px)
+        calib = CalibrationParams.from_reference(
+            req.ref_len_m, req.ref_len_px, req.fps
+        )
+        result = analyze_frames(frames, calib)
+        return AnalyzeResponse(**result)
+
+    events = [e.frame_index for e in ImpactDetector().run(frames)]
     ball = [(i * req.ball_dx_px, 100 + i * req.ball_dy_px) for i in range(req.frames)]
     club = [(i * req.club_dx_px, 110 + i * req.club_dy_px) for i in range(req.frames)]
-
     calib = CalibrationParams.from_reference(req.ref_len_m, req.ref_len_px, req.fps)
     m = measure_from_tracks(ball, club, calib)
-
     return AnalyzeResponse(events=events, metrics=as_dict(m))

--- a/server/routes/cv_mock.py
+++ b/server/routes/cv_mock.py
@@ -41,9 +41,7 @@ def analyze(req: AnalyzeRequest):
         os.environ["GOLFIQ_MOTION_DY_BALL"] = str(req.ball_dy_px)
         os.environ["GOLFIQ_MOTION_DX_CLUB"] = str(req.club_dx_px)
         os.environ["GOLFIQ_MOTION_DY_CLUB"] = str(req.club_dy_px)
-        calib = CalibrationParams.from_reference(
-            req.ref_len_m, req.ref_len_px, req.fps
-        )
+        calib = CalibrationParams.from_reference(req.ref_len_m, req.ref_len_px, req.fps)
         result = analyze_frames(frames, calib)
         return AnalyzeResponse(**result)
 

--- a/server/tests/test_cv_mock_analyze_detector.py
+++ b/server/tests/test_cv_mock_analyze_detector.py
@@ -1,6 +1,7 @@
 from fastapi.testclient import TestClient
 from server.app import app
 
+
 def test_cv_mock_analyze_detector_mode():
     client = TestClient(app)
     payload = {

--- a/server/tests/test_cv_mock_analyze_detector.py
+++ b/server/tests/test_cv_mock_analyze_detector.py
@@ -1,0 +1,23 @@
+from fastapi.testclient import TestClient
+from server.app import app
+
+def test_cv_mock_analyze_detector_mode():
+    client = TestClient(app)
+    payload = {
+        "mode": "detector",
+        "frames": 10,
+        "fps": 120.0,
+        "ref_len_m": 1.0,
+        "ref_len_px": 100.0,
+        "ball_dx_px": 2.0,
+        "ball_dy_px": -1.0,
+        "club_dx_px": 1.5,
+        "club_dy_px": 0.0,
+    }
+    r = client.post("/cv/mock/analyze", json=payload)
+    assert r.status_code == 200, r.text
+    data = r.json()
+    m = data["metrics"]
+    assert abs(m["ball_speed_mps"] - 2.68) < 0.2
+    assert 5.7 <= m["ball_speed_mph"] <= 6.3
+    assert 25.0 <= m["launch_deg"] <= 28.5


### PR DESCRIPTION
## Summary
- allow YoloV8Detector to simulate deterministic motion based on env vars
- add lightweight pipeline that builds tracks, computes metrics, and detects impacts
- extend mock analysis endpoint to support `mode="detector"` using new pipeline
- add docs and tests for detector-driven pipeline

## Testing
- `pytest cv_engine/tests/test_pipeline_mock.py server/tests/test_cv_mock_analyze.py server/tests/test_cv_mock_analyze_detector.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5d303402c8326828fe78bf6fd310f