### PR TITLE
feat(video): extras [video] + frames_from_video + /cv/analyze/video + tests

### DIFF
--- a/.github/workflows/video-extras.yml
+++ b/.github/workflows/video-extras.yml
@@ -1,0 +1,21 @@
+name: video-extras
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  video:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.11' }
+      - name: Install deps (with video extras)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt || true
+          pip install -r requirements-dev.txt
+          pip install -e ".[video]"
+      - name: Run video tests (cv_engine + server)
+        run: pytest -q cv_engine/tests/test_videoreader.py server/tests/test_cv_analyze_video.py

--- a/README.md
+++ b/README.md
@@ -38,6 +38,21 @@ curl -X POST "http://localhost:8000/cv/analyze" \
   -F "frames_zip=@/path/to/frames.zip"
 ```
 
+### Video support (optional)
+Install once:
+
+```
+pip install -e ".[video]"
+```
+
+Analyze an MP4:
+
+```
+curl -X POST "http://localhost:8000/cv/analyze/video" \
+  -F "video=@/path/to/clip.mp4" \
+  -F "ref_len_m=1.0" -F "ref_len_px=100" -F "fps_fallback=120"
+```
+
 ## CI & Coverage
 
 A separate workflow publishes cv_engine coverage as an artifact (report-only).

--- a/cv_engine/io/videoreader.py
+++ b/cv_engine/io/videoreader.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import os
+import tempfile
+from typing import List, Union
+
+import numpy as np
+
+
+def frames_from_video(
+    src: Union[str, bytes], max_frames: int | None = None, stride: int = 1
+) -> List["np.ndarray"]:
+    """
+    Läs frames från video (MP4 m.fl.) till list[(H,W,3) uint8 RGB].
+    - src: filväg eller bytes (vid bytes skrivs tempfil)
+    - max_frames: max antal frames att returnera
+    - stride: hoppa var 'stride':e frame (1 = alla)
+    Kräver extras [video] (cv2). Om cv2 saknas: raise ImportError.
+    """
+    import numpy as np
+
+    try:
+        import cv2  # type: ignore
+    except Exception as e:
+        raise ImportError(
+            "Video extras not installed. Use pip install -e '.[video]'"
+        ) from e
+
+    cleanup = None
+    path = src
+    if isinstance(src, (bytes, bytearray)):
+        fd, tmp = tempfile.mkstemp(suffix=".mp4")
+        os.close(fd)
+        with open(tmp, "wb") as f:
+            f.write(src)
+        path = tmp
+        cleanup = tmp
+
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        if cleanup:
+            os.remove(cleanup)
+        raise RuntimeError(f"Unable to open video: {path}")
+
+    frames: List["np.ndarray"] = []
+    idx = 0
+    keep = True
+    while keep:
+        ok, frame_bgr = cap.read()
+        if not ok:
+            break
+        if idx % max(1, stride) == 0:
+            frame_rgb = frame_bgr[:, :, ::-1]
+            if frame_rgb.dtype != np.uint8:
+                frame_rgb = frame_rgb.astype(np.uint8)
+            frames.append(frame_rgb)
+            if max_frames is not None and len(frames) >= max_frames:
+                break
+        idx += 1
+
+    cap.release()
+    if cleanup:
+        os.remove(cleanup)
+    return frames
+
+
+def fps_from_video(src: Union[str, bytes]) -> float:
+    """Försök läsa FPS från video. Returnerar >0 vid framgång, annars 0."""
+    try:
+        import cv2  # type: ignore
+    except Exception:
+        return 0.0
+    import os
+    import tempfile
+
+    cleanup = None
+    path = src
+    if isinstance(src, (bytes, bytearray)):
+        fd, tmp = tempfile.mkstemp(suffix=".mp4")
+        os.close(fd)
+        with open(tmp, "wb") as f:
+            f.write(src)
+        path = tmp
+        cleanup = tmp
+    cap = cv2.VideoCapture(str(path))
+    fps = float(cap.get(5))  # CAP_PROP_FPS
+    cap.release()
+    if cleanup:
+        os.remove(cleanup)
+    return fps if fps and fps > 0 else 0.0

--- a/cv_engine/tests/test_videoreader.py
+++ b/cv_engine/tests/test_videoreader.py
@@ -1,0 +1,33 @@
+import os
+import tempfile
+
+import numpy as np
+import pytest
+
+cv2 = pytest.importorskip("cv2")
+
+
+def _tmp_mp4_path(frames=10, w=64, h=64):
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    fd, path = tempfile.mkstemp(suffix=".mp4")
+    os.close(fd)
+    writer = cv2.VideoWriter(path, fourcc, 30.0, (w, h))
+    for i in range(frames):
+        img = np.zeros((h, w, 3), dtype=np.uint8)
+        img[:] = (i % 255, 0, 0)
+        writer.write(img[:, :, ::-1])  # RGB->BGR
+    writer.release()
+    return path
+
+
+def test_frames_from_video_reads_frames():
+    from cv_engine.io.videoreader import fps_from_video, frames_from_video
+
+    path = _tmp_mp4_path(frames=12)
+    try:
+        out = frames_from_video(path, max_frames=10)
+        assert len(out) == 10 and out[0].shape[2] == 3
+        fps = fps_from_video(path)
+        assert fps > 0
+    finally:
+        os.remove(path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,9 @@ line-length = 88
 [tool.isort]
 profile = "black"
 line_length = 88
+
+[project.optional-dependencies]
+video = [
+  "opencv-python-headless>=4.8",
+  "imageio[ffmpeg]>=2.34",
+]

--- a/server/app.py
+++ b/server/app.py
@@ -2,6 +2,8 @@ from server.api.main import app
 from server.routes.cv_mock import router as cv_mock_router
 
 from .routes.cv_analyze import router as cv_analyze_router
+from .routes.cv_analyze_video import router as cv_analyze_video_router
 
 app.include_router(cv_mock_router)
 app.include_router(cv_analyze_router)
+app.include_router(cv_analyze_video_router)

--- a/server/routes/cv_analyze_video.py
+++ b/server/routes/cv_analyze_video.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import os
+
+from fastapi import APIRouter, File, HTTPException, UploadFile
+from pydantic import BaseModel, Field
+
+from cv_engine.io.videoreader import fps_from_video, frames_from_video
+from cv_engine.metrics.kinematics import CalibrationParams
+from cv_engine.pipeline.analyze import analyze_frames
+
+router = APIRouter(prefix="/cv", tags=["cv-video"])
+
+
+class AnalyzeVideoQuery(BaseModel):
+    # Om FPS inte kan läsas ur filen, använd fallback
+    fps_fallback: float = Field(120, gt=0)
+    ref_len_m: float = Field(1.0, gt=0)
+    ref_len_px: float = Field(100.0, gt=0)
+    smoothing_window: int = 3
+
+
+class AnalyzeResponse(BaseModel):
+    events: list[int]
+    metrics: dict
+
+
+@router.post("/analyze/video", response_model=AnalyzeResponse)
+async def analyze_video(
+    query: AnalyzeVideoQuery,
+    video: UploadFile = File(..., description="Video (e.g., MP4)"),
+):
+    # CV i mock-läge (deterministiskt) om inget riktigt weight finns
+    os.environ.setdefault("GOLFIQ_MOCK", "1")
+    data = await video.read()
+    try:
+        frames = frames_from_video(data, max_frames=300, stride=1)
+    except ImportError:
+        raise HTTPException(
+            400, "Video extras not installed. Install with: pip install -e '.[video]'"
+        )
+    if len(frames) < 2:
+        raise HTTPException(400, "Could not decode video or not enough frames.")
+
+    fps = fps_from_video(data) or float(query.fps_fallback)
+    calib = CalibrationParams.from_reference(query.ref_len_m, query.ref_len_px, fps)
+    result = analyze_frames(frames, calib)
+    return AnalyzeResponse(**result)

--- a/server/tests/test_cv_analyze_video.py
+++ b/server/tests/test_cv_analyze_video.py
@@ -1,0 +1,44 @@
+import os
+import tempfile
+
+import numpy as np
+import pytest
+
+cv2 = pytest.importorskip("cv2")
+
+
+def _mp4_bytes(frames=10, w=64, h=64):
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    fd, path = tempfile.mkstemp(suffix=".mp4")
+    os.close(fd)
+    writer = cv2.VideoWriter(path, fourcc, 30.0, (w, h))
+    for i in range(frames):
+        img = np.zeros((h, w, 3), dtype=np.uint8)
+        img[:] = (i % 255, 0, 0)
+        writer.write(img[:, :, ::-1])
+    writer.release()
+    with open(path, "rb") as f:
+        data = f.read()
+    os.remove(path)
+    return data
+
+
+def test_cv_analyze_video_endpoint():
+    from fastapi.testclient import TestClient
+
+    from server.app import app
+
+    client = TestClient(app)
+
+    video_bytes = _mp4_bytes(frames=12)
+    files = {"video": ("test.mp4", video_bytes, "video/mp4")}
+    data = {
+        "fps_fallback": "120",
+        "ref_len_m": "1.0",
+        "ref_len_px": "100.0",
+        "smoothing_window": "3",
+    }
+    r = client.post("/cv/analyze/video", data=data, files=files)
+    assert r.status_code == 200, r.text
+    m = r.json()["metrics"]
+    assert 0.0 <= m["confidence"] <= 1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,3 +12,8 @@ include =
     server
     golfiq
     contracts
+
+[options.extras_require]
+video =
+    opencv-python-headless>=4.8
+    imageio[ffmpeg]>=2.34


### PR DESCRIPTION
## Summary
- add optional video extras for OpenCV and ffmpeg
- implement frames_from_video utility and fps_from_video helper
- add /cv/analyze/video endpoint with analysis pipeline
- cover with tests and dedicated video workflow

## Testing
- `pre-commit run --files pyproject.toml setup.cfg cv_engine/io/videoreader.py cv_engine/pipeline/analyze.py server/routes/cv_analyze_video.py server/app.py cv_engine/tests/test_videoreader.py server/tests/test_cv_analyze_video.py README.md .github/workflows/video-extras.yml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5ebfe18a48326b422af584f6caa9c