### PR TITLE
ci: gate auto-merge workflow on main CI success

### DIFF
--- a/.github/workflows/auto-merge-green.yml
+++ b/.github/workflows/auto-merge-green.yml
@@ -1,14 +1,15 @@
 name: Auto Merge Green PRs
 
 on:
+  # Manual + timed kicks only
   workflow_dispatch:
   schedule:
-    - cron: "*/30 7-19 * * 1-5"   # optional; keep or adjust
-  pull_request:
-    types: [synchronize, reopened, labeled, ready_for_review]
-    paths-ignore:
-      - '.github/workflows/**auto-merge**.yml'
-      - '.github/workflows/**auto_merge**.yml'
+    - cron: "*/30 7-19 * * 1-5"
+  # Run after CI completes on main (prevents self-trigger and noisy PR runs)
+  workflow_run:
+    workflows: ["ci"]
+    types: [completed]
+    branches: [main]
 
 permissions:
   contents: write
@@ -21,41 +22,31 @@ concurrency:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    # Do NOT run on PRs from forks, or on the PR that modifies this workflow
-    if: >
-      ${{
-        github.event_name != 'pull_request' ||
-        (
-          github.event.pull_request.head.repo.full_name == github.repository &&
-          !contains(github.event.pull_request.title, 'auto-merge')
-        )
-      }}
+    # Only act when CI on main succeeded
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v4
-
       - uses: cli/gh-action@v2
 
-      - name: Find mergeable PRs
+      - name: Find mergeable PRs (CLEAN)
         id: find
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # gh prefers GH_TOKEN; GITHUB_TOKEN also works
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          # CLEAN = all checks green & mergeable
           prs="$(gh pr list --state open \
                  --json number,isDraft,mergeStateStatus \
                  --jq '.[] | select(.isDraft==false) | select(.mergeStateStatus==\"CLEAN\") | .number' \
                  || true)"
           echo "prs=${prs}" >> "$GITHUB_OUTPUT"
-          count="$(wc -w <<<"$prs" | tr -d ' ')"
-          echo "count=${count}" >> "$GITHUB_OUTPUT"
-          echo "Found $count CLEAN PR(s)."
+          echo "count=$(wc -w <<<"$prs" | tr -d ' ')" >> "$GITHUB_OUTPUT"
+          echo "Found: $prs"
 
       - name: Exit quietly if none
         if: ${{ steps.find.outputs.count == '0' }}
-        run: echo "No green PRs. Exiting 0."
+        run: echo "No CLEAN PRs to merge. Exiting 0."
 
-      - name: Merge PRs (squash + delete branch; allow auto-merge)
+      - name: Merge PRs (squash + delete branch; allow auto)
         if: ${{ steps.find.outputs.count != '0' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- replace the Auto Merge Green PRs workflow to listen to manual, schedule, and CI-on-main completions
- skip PR-triggered executions, exit cleanly when no CLEAN PRs, and keep squash merges via gh CLI

## Testing
- Triggered `Auto Merge Green PRs` workflow via `workflow_dispatch` on `codex/update-auto-merge-green-prs-workflow` (run 17742102876)
- Triggered `Auto Merge Green PRs` workflow via `workflow_dispatch` on `dependabot/github_actions/actions/setup-python-6` (run 17742108174)


------
https://chatgpt.com/codex/tasks/task_e_68c84ffc42ac8326802c9c6710006a1b