### PR TITLE
Normalize setup-python@v6 usage in workflows

### DIFF
--- a/.github/workflows/bulk-pr-sync.yml
+++ b/.github/workflows/bulk-pr-sync.yml
@@ -15,8 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with: { fetch-depth: 0 }
-      - uses: actions/setup-python@v5
-        with: { python-version: "3.11", cache: "pip" }
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: "pip"
       - name: Install tools
         run: python -m pip install -U pip black isort
       - name: Configure git user

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: "3.11"
       - run: pip install -r requirements-dev.txt
       - run: black --check .
       - run: flake8 .
@@ -26,9 +26,9 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/cv-engine-coverage.yml
+++ b/.github/workflows/cv-engine-coverage.yml
@@ -8,8 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-python@v5
-        with: { python-version: '3.11' }
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
       - name: Install deps
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/pr-repair.yml
+++ b/.github/workflows/pr-repair.yml
@@ -20,8 +20,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with: { fetch-depth: 0 }
-      - uses: actions/setup-python@v5
-        with: { python-version: "3.11", cache: "pip" }
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: "pip"
       - name: Install deps
         run: |
           python -m pip install -U pip

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -10,8 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-python@v5
-        with: { python-version: '3.11' }
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
       - name: Install deps
         run: |
           pip install -r requirements.txt || true
@@ -29,8 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-python@v5
-        with: { python-version: '3.11' }
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
       - name: Install bandit
         run: pip install bandit
       - name: Run bandit (report-only)
@@ -46,8 +48,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-python@v5
-        with: { python-version: '3.11' }
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
       - name: Install pip-audit
         run: pip install pip-audit
       - name: Run pip-audit (report-only)

--- a/.github/workflows/video-extras.yml
+++ b/.github/workflows/video-extras.yml
@@ -9,8 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-python@v5
-        with: { python-version: '3.11' }
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
       - name: Install deps (with video extras)
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- update CI, static analysis, coverage, bulk sync, and repair workflows to use actions/setup-python@v6 with an explicit "3.11" version

## Testing
- python -m yamllint -d '{extends: default, rules: {document-start: disable, truthy: disable, line-length: disable, braces: disable, trailing-spaces: disable, empty-lines: disable}}' .github/workflows/ci.yml .github/workflows/static-analysis.yml .github/workflows/cv-engine-coverage.yml .github/workflows/video-extras.yml .github/workflows/bulk-pr-sync.yml .github/workflows/pr-repair.yml

------
https://chatgpt.com/codex/tasks/task_e_68c857ad043c83269c01f021c5832933