### PR TITLE
chore: address audit actions (cv coverage report-only, runs API, confidence asserts)

### DIFF
--- a/.github/workflows/cv-engine-coverage.yml
+++ b/.github/workflows/cv-engine-coverage.yml
@@ -17,9 +17,10 @@ jobs:
           pip install -r requirements.txt || true
           pip install -r requirements-dev.txt
           pip install -e .
-      - name: Run cv_engine tests with coverage
-        run: pytest -q cv_engine --cov=cv_engine --cov-report=xml
+      - name: Run cv_engine tests with coverage (report-only)
+        run: pytest -q cv_engine --cov=cv_engine --cov-report=xml || true
       - name: Upload cv_engine coverage
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: cv_engine-coverage-xml

--- a/cv_engine/metrics/quality.py
+++ b/cv_engine/metrics/quality.py
@@ -1,0 +1,18 @@
+from typing import Iterable, Tuple
+from math import sqrt
+Point = Tuple[float, float]
+def _speeds(pts:list[Point])->list[float]:
+    return [sqrt((x1-x0)**2+(y1-y0)**2) for (x0,y0),(x1,y1) in zip(pts,pts[1:])]
+def confidence(trk_ball: Iterable[Point], trk_club: Iterable[Point], n_frames:int)->float:
+    b=list(trk_ball); c=list(trk_club)
+    if n_frames<=0: return 0.0
+    continuity = min(len(b),len(c))/n_frames
+    import statistics as st
+    def stab(pts:list[Point])->float:
+        v=_speeds(pts)
+        if len(v)<2: return 0.0
+        mu=max(1e-6, st.fmean(v)); cv=min(1.0, (st.pstdev(v)/mu))
+        return 1.0 - cv
+    stability = 0.5*stab(b)+0.5*stab(c)
+    score = max(0.0, min(1.0, 0.6*continuity + 0.4*stability))
+    return round(score, 3)

--- a/cv_engine/metrics/smoothing.py
+++ b/cv_engine/metrics/smoothing.py
@@ -1,0 +1,11 @@
+from typing import Iterable, List, Tuple
+Point = Tuple[float, float]
+def moving_average(track: Iterable[Point], window: int = 3) -> List[Point]:
+    pts=list(track); 
+    if window<=1 or len(pts)<=2: return pts
+    w=max(1,int(window)); out=[]
+    for i in range(len(pts)):
+        a=max(0,i-(w//2)); b=min(len(pts), i+(w//2)+1)
+        xs=[p[0] for p in pts[a:b]]; ys=[p[1] for p in pts[a:b]]
+        out.append((sum(xs)/len(xs), sum(ys)/len(ys)))
+    return out

--- a/server/app.py
+++ b/server/app.py
@@ -3,7 +3,9 @@ from server.routes.cv_mock import router as cv_mock_router
 
 from .routes.cv_analyze import router as cv_analyze_router
 from .routes.cv_analyze_video import router as cv_analyze_video_router
+from .routes.runs import router as runs_router
 
 app.include_router(cv_mock_router)
 app.include_router(cv_analyze_router)
 app.include_router(cv_analyze_video_router)
+app.include_router(runs_router)

--- a/server/routes/cv_analyze.py
+++ b/server/routes/cv_analyze.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field
 from cv_engine.io.framesource import frames_from_zip_bytes
 from cv_engine.metrics.kinematics import CalibrationParams
 from cv_engine.pipeline.analyze import analyze_frames
+from server.storage.runs import save_run
 
 router = APIRouter(prefix="/cv", tags=["cv"])
 
@@ -17,11 +18,14 @@ class AnalyzeQuery(BaseModel):
     ref_len_m: float = Field(1.0, gt=0)
     ref_len_px: float = Field(100.0, gt=0)
     mode: str = "detector"  # "detector" | "tracks" ( tracks ej stödd här )
+    persist: bool = False
+    run_name: str | None = None
 
 
 class AnalyzeResponse(BaseModel):
     events: list[int]
     metrics: dict
+    run_id: str | None = None
 
 
 @router.post("/analyze", response_model=AnalyzeResponse)
@@ -41,4 +45,17 @@ async def analyze(
         query.ref_len_m, query.ref_len_px, query.fps
     )
     result = analyze_frames(frames, calib)  # använder detektor + vår pipeline
-    return AnalyzeResponse(**result)
+    events = result["events"]
+    metrics = result["metrics"]
+    if "confidence" not in metrics:
+        metrics["confidence"] = 0.0
+    rec = None
+    if query.persist:
+        rec = save_run(
+            source="zip",
+            mode=getattr(query, "mode", "detector"),
+            params=query.model_dump(),
+            metrics=dict(metrics),
+            events=list(events),
+        )
+    return AnalyzeResponse(events=events, metrics=metrics, run_id=rec.run_id if rec else None)

--- a/server/routes/cv_analyze_video.py
+++ b/server/routes/cv_analyze_video.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field
 from cv_engine.io.videoreader import fps_from_video, frames_from_video
 from cv_engine.metrics.kinematics import CalibrationParams
 from cv_engine.pipeline.analyze import analyze_frames
+from server.storage.runs import save_run
 
 router = APIRouter(prefix="/cv", tags=["cv-video"])
 
@@ -18,11 +19,14 @@ class AnalyzeVideoQuery(BaseModel):
     ref_len_m: float = Field(1.0, gt=0)
     ref_len_px: float = Field(100.0, gt=0)
     smoothing_window: int = 3
+    persist: bool = False
+    run_name: str | None = None
 
 
 class AnalyzeResponse(BaseModel):
     events: list[int]
     metrics: dict
+    run_id: str | None = None
 
 
 @router.post("/analyze/video", response_model=AnalyzeResponse)
@@ -31,6 +35,8 @@ async def analyze_video(
     ref_len_m: float = Form(1.0, gt=0),
     ref_len_px: float = Form(100.0, gt=0),
     smoothing_window: int = Form(3),
+    persist: bool = Form(False),
+    run_name: str | None = Form(None),
     video: UploadFile = File(..., description="Video (e.g., MP4)"),
 ):
     query = AnalyzeVideoQuery(
@@ -38,6 +44,8 @@ async def analyze_video(
         ref_len_m=ref_len_m,
         ref_len_px=ref_len_px,
         smoothing_window=smoothing_window,
+        persist=persist,
+        run_name=run_name,
     )
     # CV i mock-läge (deterministiskt) om inget riktigt weight finns
     os.environ.setdefault("GOLFIQ_MOCK", "1")
@@ -54,4 +62,17 @@ async def analyze_video(
     fps = fps_from_video(data) or float(query.fps_fallback)
     calib = CalibrationParams.from_reference(query.ref_len_m, query.ref_len_px, fps)
     result = analyze_frames(frames, calib)
-    return AnalyzeResponse(**result)
+    events = result["events"]
+    metrics = result["metrics"]
+    if "confidence" not in metrics:
+        metrics["confidence"] = 0.0
+    rec = None
+    if query.persist:
+        rec = save_run(
+            source="video",
+            mode="detector",
+            params=query.model_dump(),
+            metrics=dict(metrics),
+            events=list(events),
+        )
+    return AnalyzeResponse(events=events, metrics=metrics, run_id=rec.run_id if rec else None)

--- a/server/routes/cv_mock.py
+++ b/server/routes/cv_mock.py
@@ -9,7 +9,9 @@ from pydantic import BaseModel, Field
 from cv_engine.calibration.simple import as_dict, measure_from_tracks
 from cv_engine.impact.detector import ImpactDetector
 from cv_engine.metrics.kinematics import CalibrationParams
+from cv_engine.metrics.quality import confidence as quality_confidence
 from cv_engine.pipeline.analyze import analyze_frames
+from server.storage.runs import save_run
 
 router = APIRouter(prefix="/cv/mock", tags=["cv-mock"])
 
@@ -24,11 +26,14 @@ class AnalyzeRequest(BaseModel):
     club_dx_px: float = 1.5
     club_dy_px: float = 0.0
     mode: str = "tracks"  # "tracks" | "detector"
+    persist: bool = False
+    run_name: str | None = None
 
 
 class AnalyzeResponse(BaseModel):
     events: list[int]
     metrics: dict
+    run_id: str | None = None
 
 
 @router.post("/analyze", response_model=AnalyzeResponse)
@@ -43,11 +48,26 @@ def analyze(req: AnalyzeRequest):
         os.environ["GOLFIQ_MOTION_DY_CLUB"] = str(req.club_dy_px)
         calib = CalibrationParams.from_reference(req.ref_len_m, req.ref_len_px, req.fps)
         result = analyze_frames(frames, calib)
-        return AnalyzeResponse(**result)
+        events = result["events"]
+        metrics = result["metrics"]
+    else:
+        events = [e.frame_index for e in ImpactDetector().run(frames)]
+        ball = [(i * req.ball_dx_px, 100 + i * req.ball_dy_px) for i in range(req.frames)]
+        club = [(i * req.club_dx_px, 110 + i * req.club_dy_px) for i in range(req.frames)]
+        calib = CalibrationParams.from_reference(req.ref_len_m, req.ref_len_px, req.fps)
+        m = measure_from_tracks(ball, club, calib)
+        metrics = as_dict(m)
+        metrics["confidence"] = quality_confidence(ball, club, req.frames)
 
-    events = [e.frame_index for e in ImpactDetector().run(frames)]
-    ball = [(i * req.ball_dx_px, 100 + i * req.ball_dy_px) for i in range(req.frames)]
-    club = [(i * req.club_dx_px, 110 + i * req.club_dy_px) for i in range(req.frames)]
-    calib = CalibrationParams.from_reference(req.ref_len_m, req.ref_len_px, req.fps)
-    m = measure_from_tracks(ball, club, calib)
-    return AnalyzeResponse(events=events, metrics=as_dict(m))
+    rec = None
+    if req.persist:
+        rec = save_run(
+            source="mock",
+            mode=getattr(req, "mode", "detector"),
+            params=req.model_dump(),
+            metrics=dict(metrics),
+            events=list(events),
+        )
+    if "confidence" not in metrics:
+        metrics["confidence"] = 0.0
+    return AnalyzeResponse(events=events, metrics=metrics, run_id=rec.run_id if rec else None)

--- a/server/routes/runs.py
+++ b/server/routes/runs.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel
+from typing import List
+from ..storage.runs import list_runs, load_run, delete_run, RunRecord
+
+router = APIRouter(prefix="/runs", tags=["runs"])
+
+class RunListItem(BaseModel):
+    run_id: str; created_ts: float; source: str; mode: str
+    confidence: float | None = None; ball_speed_mps: float | None = None
+
+def _item(r: RunRecord) -> RunListItem:
+    m = r.metrics or {}
+    return RunListItem(run_id=r.run_id, created_ts=r.created_ts, source=r.source, mode=r.mode,
+                       confidence=m.get("confidence"), ball_speed_mps=m.get("ball_speed_mps"))
+
+@router.get("", response_model=List[RunListItem])
+def get_runs(limit: int = Query(50, ge=1, le=200)): return [_item(r) for r in list_runs(limit)]
+
+@router.get("/{run_id}")
+def get_run(run_id: str):
+    r = load_run(run_id)
+    if not r: raise HTTPException(404, "run not found")
+    return {"run_id": r.run_id, "created_ts": r.created_ts, "source": r.source, "mode": r.mode,
+            "params": r.params, "metrics": r.metrics, "events": r.events}
+
+@router.delete("/{run_id}")
+def delete(run_id: str):
+    if not delete_run(run_id): raise HTTPException(404, "run not found")
+    return {"deleted": run_id}

--- a/server/storage/runs.py
+++ b/server/storage/runs.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+import json, time, uuid, os
+
+RUNS_DIR = Path(os.getenv("GOLFIQ_RUNS_DIR", "data/runs")).resolve()
+
+@dataclass(frozen=True)
+class RunRecord:
+    run_id: str
+    created_ts: float
+    source: str
+    mode: str
+    params: Dict[str, Any]
+    metrics: Dict[str, Any]
+    events: List[int]
+
+def _dir(run_id: str) -> Path: return RUNS_DIR / run_id
+
+def save_run(*, source: str, mode: str, params: Dict[str, Any], metrics: Dict[str, Any], events: List[int]) -> RunRecord:
+    RUNS_DIR.mkdir(parents=True, exist_ok=True)
+    rid = f"{int(time.time())}-{uuid.uuid4().hex[:8]}"
+    rec = RunRecord(rid, time.time(), source, mode, params, metrics, events)
+    d = _dir(rid); d.mkdir(parents=True, exist_ok=True)
+    (d / "run.json").write_text(json.dumps(asdict(rec), indent=2))
+    return rec
+
+def load_run(run_id: str) -> Optional[RunRecord]:
+    p = _dir(run_id) / "run.json"
+    if not p.exists(): return None
+    return RunRecord(**json.loads(p.read_text()))
+
+def delete_run(run_id: str) -> bool:
+    d = _dir(run_id)
+    if not d.exists(): return False
+    for c in d.iterdir(): c.unlink()
+    d.rmdir()
+    return True
+
+def list_runs(limit: int = 50) -> List[RunRecord]:
+    if not RUNS_DIR.exists(): return []
+    out: List[RunRecord] = []
+    for d in sorted(RUNS_DIR.iterdir(), reverse=True):
+        p = d / "run.json"
+        if p.exists():
+            try: out.append(RunRecord(**json.loads(p.read_text())))
+            except Exception: pass
+        if len(out) >= max(1, limit): break
+    return out

--- a/server/tests/test_cv_mock_analyze.py
+++ b/server/tests/test_cv_mock_analyze.py
@@ -28,3 +28,4 @@ def test_cv_mock_analyze_returns_metrics():
     assert 25.0 <= m["launch_deg"] <= 28.5
     # Carry positiv och rimlig för låg hastighet
     assert m["carry_m"] > 0.0
+    assert "confidence" in m and 0.0 <= m["confidence"] <= 1.0

--- a/server/tests/test_cv_upload_analyze.py
+++ b/server/tests/test_cv_upload_analyze.py
@@ -35,3 +35,4 @@ def test_cv_upload_analyze_npy_zip():
     m = data["metrics"]
     # grova sanity checks (mock-detektor ger deterministisk rörelse)
     assert "ball_speed_mps" in m and m["carry_m"] >= 0
+    assert "confidence" in m and 0.0 <= m["confidence"] <= 1.0

--- a/server/tests/test_runs_api.py
+++ b/server/tests/test_runs_api.py
@@ -1,0 +1,13 @@
+from fastapi.testclient import TestClient
+from server.app import app
+
+def test_runs_lifecycle():
+    client = TestClient(app)
+    assert client.get("/runs").status_code == 200
+    payload = {"mode":"detector","frames":6,"fps":120.0,"ref_len_m":1.0,"ref_len_px":100.0,
+               "ball_dx_px":2.0,"ball_dy_px":-1.0,"club_dx_px":1.5,"club_dy_px":0.0,"persist": True}
+    r = client.post("/cv/mock/analyze", json=payload); assert r.status_code==200
+    rid = r.json().get("run_id"); assert rid
+    assert any(it["run_id"]==rid for it in client.get("/runs").json())
+    assert client.get(f"/runs/{rid}").status_code==200
+    assert client.delete(f"/runs/{rid}").status_code==200


### PR DESCRIPTION
## Summary
- make the cv-engine coverage workflow report-only and always publish the XML artifact
- add run persistence storage, expose /runs list/get/delete endpoints, and attach run_ids to CV analyze responses when requested
- ensure confidence is asserted in CV tests and restore the missing metrics helpers

## Testing
- pytest server/tests

------
https://chatgpt.com/codex/tasks/task_e_68c864efa0e8832694d276812572af5e