### PR TITLE
build(release): Dockerfile + GHCR publish on tag + docker-compose + smoke test

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+__pycache__/
+*.pyc
+*.pyo
+*.pytest_cache/
+.venv/
+env/
+web/node_modules/
+web/dist/
+.github/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=tag
+            type=sha
+            type=raw,value=latest
+      - name: Build & push (multi-arch)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VIDEO_EXTRAS=1
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  smoke-test:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pull image
+        run: docker pull ghcr.io/${{ github.repository }}:latest
+      - name: Run container
+        run: |
+          cid=$(docker run -d -e SERVE_WEB=0 -p 8000:8000 ghcr.io/${{ github.repository }}:latest)
+          echo "$cid" > cid.txt
+          sleep 5
+      - name: Health check
+        run: |
+          curl -f http://localhost:8000/health || (docker logs $(cat cid.txt) && exit 1)
+      - name: Cleanup
+        if: always()
+        run: docker rm -f $(cat cid.txt)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+# -------- Web build --------
+FROM node:20-slim AS web
+WORKDIR /web
+COPY web/package.json web/package-lock.json* ./
+RUN npm ci || npm install
+COPY web/ .
+RUN npm run build
+
+# -------- Python runtime --------
+ARG PY_IMAGE=python:3.11-slim
+FROM ${PY_IMAGE} AS runtime
+
+# System libs for opencv/ffmpeg (video extras)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      libgl1 libglib2.0-0 ffmpeg ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+# Install deps first (cache friendly)
+COPY requirements.txt* requirements-dev.txt* ./
+RUN pip install --upgrade pip && \
+    (pip install -r requirements.txt || true) && \
+    pip install -r requirements-dev.txt
+
+# Optionally install video extras
+ARG VIDEO_EXTRAS=0
+
+# App code
+COPY . .
+# Prebuilt web bundle
+COPY --from=web /web/dist /app/web/dist
+
+# Install package (editable not needed in container)
+RUN pip install -e .
+
+# Optionally install video extras
+RUN if [ "$VIDEO_EXTRAS" = "1" ]; then pip install -e ".[video]"; fi
+
+# Non-root
+RUN useradd -m appuser && chown -R appuser:app /app
+USER appuser
+
+ENV SERVE_WEB=1 PORT=8000 HOST=0.0.0.0 GOLFIQ_MOCK=1 GOLFIQ_RUNS_DIR=/data/runs
+EXPOSE 8000
+VOLUME ["/data/runs"]
+
+CMD ["uvicorn", "server.app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -79,6 +79,19 @@ When `SERVE_WEB=1` the FastAPI server mounts the compiled SPA from `web/dist` an
 
 The UI currently calls the following endpoints: `/cv/mock/analyze`, `/cv/analyze`, `/cv/analyze/video`, and `/runs` (including `/runs/{id}` and `DELETE /runs/{id}`).
 
+### Run with Docker
+Build locally:
+```bash
+docker build -t golfiq-yolo --build-arg VIDEO_EXTRAS=1 .
+docker run -p 8000:8000 -e SERVE_WEB=1 -e GOLFIQ_MOCK=1 -v $(pwd)/data/runs:/data/runs golfiq-yolo
+```
+
+Release image (tags v*) is published to ghcr.io/<owner>/GolfIQ-YOLO:latest. Use Compose:
+
+```
+docker compose up --build
+```
+
 ## CI & Coverage
 
 A separate workflow publishes cv_engine coverage as an artifact (report-only).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  app:
+    build:
+      context: .
+      args:
+        VIDEO_EXTRAS: "1"   # set "0" to skip video deps
+    image: ghcr.io/${GH_USER:-fatdevil}/golfiq-yolo:dev
+    ports:
+      - "8000:8000"
+    environment:
+      SERVE_WEB: "1"
+      GOLFIQ_MOCK: "1"
+      GOLFIQ_RUNS_DIR: "/data/runs"
+    volumes:
+      - ./data/runs:/data/runs


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile that builds the Vite frontend, installs FastAPI dependencies, runs as a non-root user, and exposes port 8000 with optional video extras
- add a docker-compose file for local runs with persistent run storage and default video extras enabled, plus a dockerignore to keep build context small
- add a GitHub Actions release workflow that pushes tagged images to GHCR, runs a smoke test, and document Docker usage in the README

## Testing
- not run (configuration only)


------
https://chatgpt.com/codex/tasks/task_e_68cbbff9c9fc8326afcfc4637a02e6cb