### PR TITLE
Migrate FastAPI startup hooks to lifespan

### DIFF
--- a/golfiq/server/tests/test_calibrate.py
+++ b/golfiq/server/tests/test_calibrate.py
@@ -4,8 +4,8 @@ from ..api.main import app
 
 
 def test_calibrate_endpoint():
-    c = TestClient(app)
-    r = c.get("/calibrate?a4_width_px=500.0")
-    assert r.status_code == 200
-    assert "scale_m_per_px" in r.json()
-    assert abs(r.json()["scale_m_per_px"] - (0.210 / 500.0)) < 1e-9
+    with TestClient(app) as c:
+        r = c.get("/calibrate?a4_width_px=500.0")
+        assert r.status_code == 200
+        assert "scale_m_per_px" in r.json()
+        assert abs(r.json()["scale_m_per_px"] - (0.210 / 500.0)) < 1e-9

--- a/golfiq/server/tests/test_infer_detections.py
+++ b/golfiq/server/tests/test_infer_detections.py
@@ -2,8 +2,6 @@ from fastapi.testclient import TestClient
 
 from ..api.main import app
 
-client = TestClient(app)
-
 
 def test_infer_with_detections():
     payload = {
@@ -143,7 +141,8 @@ def test_infer_with_detections():
             "calibrated": True,
         },
     }
-    r = client.post("/infer", json=payload)
+    with TestClient(app) as client:
+        r = client.post("/infer", json=payload)
     assert r.status_code == 200
     data = r.json()
     assert data["quality"] in ["green", "yellow", "red"]

--- a/golfiq/server/tests/test_infer_tracking_sortlite.py
+++ b/golfiq/server/tests/test_infer_tracking_sortlite.py
@@ -4,7 +4,6 @@ from server.api.main import app
 
 
 def test_infer_detections_sortlite():
-    client = TestClient(app)
     payload = {
         "mode": "detections",
         "detections": [
@@ -122,7 +121,8 @@ def test_infer_detections_sortlite():
         },
         "tracking": {"mode": "sortlite", "iou_thr": 0.1},
     }
-    r = client.post("/infer", json=payload)
+    with TestClient(app) as client:
+        r = client.post("/infer", json=payload)
     assert r.status_code == 200
     m = r.json()["metrics"]
     assert m["club_speed_mps"] > 0 and m["ball_speed_mps"] > 0

--- a/server/tests/test_auth_default_open.py
+++ b/server/tests/test_auth_default_open.py
@@ -4,7 +4,7 @@ from server.api.main import app
 
 
 def test_no_api_key_required_by_default():
-    c = TestClient(app)
-    # Health is always open
-    r = c.get("/health")
+    with TestClient(app) as c:
+        # Health is always open
+        r = c.get("/health")
     assert r.status_code == 200

--- a/server/tests/test_calibrate.py
+++ b/server/tests/test_calibrate.py
@@ -4,7 +4,7 @@ from server.api.main import app
 
 
 def test_calibrate_endpoint():
-    c = TestClient(app)
-    r = c.get("/calibrate?a4_width_px=500.0")
+    with TestClient(app) as c:
+        r = c.get("/calibrate?a4_width_px=500.0")
     assert r.status_code == 200
     assert abs(r.json()["scale_m_per_px"] - (0.210 / 500.0)) < 1e-9

--- a/server/tests/test_coach_mock.py
+++ b/server/tests/test_coach_mock.py
@@ -7,7 +7,7 @@ from server.api.main import app
 
 def test_coach_mock_mode():
     os.environ["COACH_FEATURE"] = "false"
-    client = TestClient(app)
-    r = client.post("/coach", json={"mode": "short", "notes": "Test"})
+    with TestClient(app) as client:
+        r = client.post("/coach", json={"mode": "short", "notes": "Test"})
     assert r.status_code == 200
     assert "sving" in r.json()["text"].lower()

--- a/server/tests/test_cv_analyze_video.py
+++ b/server/tests/test_cv_analyze_video.py
@@ -28,17 +28,16 @@ def test_cv_analyze_video_endpoint():
 
     from server.app import app
 
-    client = TestClient(app)
-
-    video_bytes = _mp4_bytes(frames=12)
-    files = {"video": ("test.mp4", video_bytes, "video/mp4")}
-    data = {
-        "fps_fallback": "120",
-        "ref_len_m": "1.0",
-        "ref_len_px": "100.0",
-        "smoothing_window": "3",
-    }
-    r = client.post("/cv/analyze/video", data=data, files=files)
+    with TestClient(app) as client:
+        video_bytes = _mp4_bytes(frames=12)
+        files = {"video": ("test.mp4", video_bytes, "video/mp4")}
+        data = {
+            "fps_fallback": "120",
+            "ref_len_m": "1.0",
+            "ref_len_px": "100.0",
+            "smoothing_window": "3",
+        }
+        r = client.post("/cv/analyze/video", data=data, files=files)
     assert r.status_code == 200, r.text
     m = r.json()["metrics"]
     assert 0.0 <= m["confidence"] <= 1.0

--- a/server/tests/test_cv_mock_analyze.py
+++ b/server/tests/test_cv_mock_analyze.py
@@ -4,18 +4,18 @@ from server.app import app
 
 
 def test_cv_mock_analyze_returns_metrics():
-    client = TestClient(app)
-    payload = {
-        "frames": 10,
-        "fps": 120.0,
-        "ref_len_m": 1.0,
-        "ref_len_px": 100.0,
-        "ball_dx_px": 2.0,
-        "ball_dy_px": -1.0,  # uppåt
-        "club_dx_px": 1.5,
-        "club_dy_px": 0.0,
-    }
-    r = client.post("/cv/mock/analyze", json=payload)
+    with TestClient(app) as client:
+        payload = {
+            "frames": 10,
+            "fps": 120.0,
+            "ref_len_m": 1.0,
+            "ref_len_px": 100.0,
+            "ball_dx_px": 2.0,
+            "ball_dy_px": -1.0,  # uppåt
+            "club_dx_px": 1.5,
+            "club_dy_px": 0.0,
+        }
+        r = client.post("/cv/mock/analyze", json=payload)
     assert r.status_code == 200, r.text
     data = r.json()
     assert "metrics" in data and "events" in data

--- a/server/tests/test_cv_mock_analyze_detector.py
+++ b/server/tests/test_cv_mock_analyze_detector.py
@@ -4,19 +4,19 @@ from server.app import app
 
 
 def test_cv_mock_analyze_detector_mode():
-    client = TestClient(app)
-    payload = {
-        "mode": "detector",
-        "frames": 10,
-        "fps": 120.0,
-        "ref_len_m": 1.0,
-        "ref_len_px": 100.0,
-        "ball_dx_px": 2.0,
-        "ball_dy_px": -1.0,
-        "club_dx_px": 1.5,
-        "club_dy_px": 0.0,
-    }
-    r = client.post("/cv/mock/analyze", json=payload)
+    with TestClient(app) as client:
+        payload = {
+            "mode": "detector",
+            "frames": 10,
+            "fps": 120.0,
+            "ref_len_m": 1.0,
+            "ref_len_px": 100.0,
+            "ball_dx_px": 2.0,
+            "ball_dy_px": -1.0,
+            "club_dx_px": 1.5,
+            "club_dy_px": 0.0,
+        }
+        r = client.post("/cv/mock/analyze", json=payload)
     assert r.status_code == 200, r.text
     data = r.json()
     m = data["metrics"]

--- a/server/tests/test_cv_upload_analyze.py
+++ b/server/tests/test_cv_upload_analyze.py
@@ -19,17 +19,17 @@ def _zip_of_npy(frames):
 
 
 def test_cv_upload_analyze_npy_zip():
-    client = TestClient(app)
-    frames = [np.zeros((64, 64, 3), dtype=np.uint8) for _ in range(10)]
-    payload = {
-        "fps": "120",
-        "ref_len_m": "1.0",
-        "ref_len_px": "100.0",
-        "mode": "detector",
-    }
-    zip_buf = _zip_of_npy(frames)
-    files = {"frames_zip": ("frames.zip", zip_buf.getvalue(), "application/zip")}
-    r = client.post("/cv/analyze", data=payload, files=files)
+    with TestClient(app) as client:
+        frames = [np.zeros((64, 64, 3), dtype=np.uint8) for _ in range(10)]
+        payload = {
+            "fps": "120",
+            "ref_len_m": "1.0",
+            "ref_len_px": "100.0",
+            "mode": "detector",
+        }
+        zip_buf = _zip_of_npy(frames)
+        files = {"frames_zip": ("frames.zip", zip_buf.getvalue(), "application/zip")}
+        r = client.post("/cv/analyze", data=payload, files=files)
     assert r.status_code == 200, r.text
     data = r.json()
     m = data["metrics"]

--- a/server/tests/test_health_api.py
+++ b/server/tests/test_health_api.py
@@ -9,21 +9,23 @@ from server_app import app  # noqa: E402
 
 
 def test_health_ok():
-    client = TestClient(app)
-    r = client.get("/health")
-    assert r.status_code == 200
-    assert r.json().get("status") == "ok"
+    with TestClient(app) as client:
+        r = client.get("/health")
+        assert r.status_code == 200
+        assert r.json().get("status") == "ok"
 
 
 def test_protected_requires_api_key_when_set(monkeypatch):
     monkeypatch.setenv("API_KEY", "secret")
-    client = TestClient(app)
-    assert client.get("/protected").status_code in (401, 403)
-    assert client.get("/protected", headers={"x-api-key": "secret"}).status_code == 200
+    with TestClient(app) as client:
+        assert client.get("/protected").status_code in (401, 403)
+        assert (
+            client.get("/protected", headers={"x-api-key": "secret"}).status_code == 200
+        )
 
 
 def test_cors_allows_localhost(monkeypatch):
     monkeypatch.setenv("CORS_ALLOW_ORIGINS", "http://localhost")
-    client = TestClient(app)
-    r = client.get("/health", headers={"Origin": "http://localhost"})
+    with TestClient(app) as client:
+        r = client.get("/health", headers={"Origin": "http://localhost"})
     assert r.headers.get("access-control-allow-origin") in ("http://localhost", "*")

--- a/server/tests/test_health_endpoint.py
+++ b/server/tests/test_health_endpoint.py
@@ -4,9 +4,9 @@ from server.api.main import app
 
 
 def test_health_ok():
-    c = TestClient(app)
-    r = c.get("/health")
-    assert r.status_code == 200
-    data = r.json()
-    assert data.get("status") == "ok"
-    assert "env" in data and "runtime" in data
+    with TestClient(app) as c:
+        r = c.get("/health")
+        assert r.status_code == 200
+        data = r.json()
+        assert data.get("status") == "ok"
+        assert "env" in data and "runtime" in data

--- a/server/tests/test_openapi_contract.py
+++ b/server/tests/test_openapi_contract.py
@@ -5,8 +5,8 @@ from server.api.main import app
 
 
 def test_openapi_paths_and_schemas_match():
-    client = TestClient(app)
-    server_spec = client.get("/openapi.json").json()
+    with TestClient(app) as client:
+        server_spec = client.get("/openapi.json").json()
     with open("contracts/api.openapi.yaml", "r", encoding="utf-8") as f:
         file_spec = yaml.safe_load(f)
     # Minikoll: path /analyze finns i båda och har POST

--- a/server/tests/test_runs_api.py
+++ b/server/tests/test_runs_api.py
@@ -4,24 +4,24 @@ from server.app import app
 
 
 def test_runs_lifecycle():
-    client = TestClient(app)
-    assert client.get("/runs").status_code == 200
-    payload = {
-        "mode": "detector",
-        "frames": 6,
-        "fps": 120.0,
-        "ref_len_m": 1.0,
-        "ref_len_px": 100.0,
-        "ball_dx_px": 2.0,
-        "ball_dy_px": -1.0,
-        "club_dx_px": 1.5,
-        "club_dy_px": 0.0,
-        "persist": True,
-    }
-    r = client.post("/cv/mock/analyze", json=payload)
-    assert r.status_code == 200
-    rid = r.json().get("run_id")
-    assert rid
-    assert any(it["run_id"] == rid for it in client.get("/runs").json())
-    assert client.get(f"/runs/{rid}").status_code == 200
-    assert client.delete(f"/runs/{rid}").status_code == 200
+    with TestClient(app) as client:
+        assert client.get("/runs").status_code == 200
+        payload = {
+            "mode": "detector",
+            "frames": 6,
+            "fps": 120.0,
+            "ref_len_m": 1.0,
+            "ref_len_px": 100.0,
+            "ball_dx_px": 2.0,
+            "ball_dy_px": -1.0,
+            "club_dx_px": 1.5,
+            "club_dy_px": 0.0,
+            "persist": True,
+        }
+        r = client.post("/cv/mock/analyze", json=payload)
+        assert r.status_code == 200
+        rid = r.json().get("run_id")
+        assert rid
+        assert any(it["run_id"] == rid for it in client.get("/runs").json())
+        assert client.get(f"/runs/{rid}").status_code == 200
+        assert client.delete(f"/runs/{rid}").status_code == 200


### PR DESCRIPTION
## Summary
- replace the deprecated `@app.on_event` startup handler in `server/api/main.py` with a FastAPI `lifespan`, keeping the retention sweeper task and cancelling it during shutdown
- update FastAPI tests under `server/tests` to create `TestClient` instances via context managers so the new lifespan runs during testing
- wrap `TestClient` usage in the golfiq server tests with context managers as well

## Testing
- black .
- isort .
- flake8 .
- pytest server/tests
- pytest golfiq/server/tests *(fails: ModuleNotFoundError: No module named 'golfiq_cv')*

------
https://chatgpt.com/codex/tasks/task_e_68cbc36c77ac83268c4be2f775217dd6