### PR TITLE
Fix release Docker build args

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
+            PY_IMAGE=python:3.11-slim
             VIDEO_EXTRAS=1
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
+# syntax=docker/dockerfile:1
 # -------- Web build --------
+ARG PY_IMAGE=python:3.11-slim
 FROM node:20-slim AS web
 WORKDIR /web
 COPY web/package.json web/package-lock.json* ./


### PR DESCRIPTION
## Summary
- declare the Dockerfile syntax directive and default `PY_IMAGE` before the first stage
- pass the `PY_IMAGE` build argument from the release workflow so the runtime stage resolves

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cc4be5a3f483269477b7c91501b0b4