### PR TITLE
feat(security): API key guard + upload limits + per-request mock params

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ When `SERVE_WEB=1` the FastAPI server mounts the compiled SPA from `web/dist` an
 
 The UI currently calls the following endpoints: `/cv/mock/analyze`, `/cv/analyze`, `/cv/analyze/video`, and `/runs` (including `/runs/{id}` and `DELETE /runs/{id}`).
 
+## Security & limits
+
+* Set `REQUIRE_API_KEY=1` to require the header `x-api-key` to match `API_KEY` for analysis and runs endpoints.
+* Uploads are bounded by defaults: ZIPs ≤ 50 MB, ≤ 400 files, compression ratio ≤ 200×, and videos ≤ 80 MB. Override with `MAX_ZIP_SIZE_BYTES`, `MAX_ZIP_FILES`, `MAX_ZIP_RATIO`, or `MAX_VIDEO_BYTES`.
+
 ## Web UI
 
 The project ships with a Vite + React single-page app for uploading captures, kicking off mock runs, and browsing persisted runs.

--- a/server/config.py
+++ b/server/config.py
@@ -1,0 +1,30 @@
+"""Configuration helpers for server constants."""
+from __future__ import annotations
+
+import os
+
+
+def _int_env(name: str, default: int) -> int:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        return default
+
+
+def _float_env(name: str, default: float) -> float:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except ValueError:
+        return default
+
+
+MAX_ZIP_SIZE_BYTES: int = _int_env("MAX_ZIP_SIZE_BYTES", 50_000_000)
+MAX_ZIP_FILES: int = _int_env("MAX_ZIP_FILES", 400)
+MAX_ZIP_RATIO: float = _float_env("MAX_ZIP_RATIO", 200.0)
+MAX_VIDEO_BYTES: int = _int_env("MAX_VIDEO_BYTES", 80_000_000)

--- a/server/config.py
+++ b/server/config.py
@@ -1,4 +1,5 @@
 """Configuration helpers for server constants."""
+
 from __future__ import annotations
 
 import os

--- a/server/routes/cv_analyze.py
+++ b/server/routes/cv_analyze.py
@@ -2,15 +2,22 @@ from __future__ import annotations
 
 import os
 
-from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+import io
+import zipfile
+
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
 from pydantic import BaseModel, Field
 
 from cv_engine.io.framesource import frames_from_zip_bytes
 from cv_engine.metrics.kinematics import CalibrationParams
 from cv_engine.pipeline.analyze import analyze_frames
+from server.config import MAX_ZIP_FILES, MAX_ZIP_RATIO, MAX_ZIP_SIZE_BYTES
+from server.security import require_api_key
 from server.storage.runs import save_run
 
-router = APIRouter(prefix="/cv", tags=["cv"])
+router = APIRouter(
+    prefix="/cv", tags=["cv"], dependencies=[Depends(require_api_key)]
+)
 
 
 class AnalyzeQuery(BaseModel):
@@ -35,8 +42,51 @@ async def analyze(
 ):
     # CV i mock-läge för determinism
     os.environ.setdefault("GOLFIQ_MOCK", "1")
-    buf = await frames_zip.read()
-    frames = frames_from_zip_bytes(buf)
+    data = await frames_zip.read(MAX_ZIP_SIZE_BYTES + 1)
+    if len(data) > MAX_ZIP_SIZE_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+            detail="ZIP too large",
+        )
+    try:
+        with zipfile.ZipFile(io.BytesIO(data)) as zf:
+            members = [m for m in zf.infolist() if not m.is_dir()]
+            if len(members) > MAX_ZIP_FILES:
+                raise HTTPException(
+                    status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+                    detail="Too many files in ZIP",
+                )
+            uncompressed_sum = sum(m.file_size for m in members)
+            compressed_sum = sum(m.compress_size for m in members)
+            if any(m.file_size > MAX_ZIP_SIZE_BYTES for m in members):
+                raise HTTPException(
+                    status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+                    detail="File too large in ZIP",
+                )
+            if compressed_sum == 0 and uncompressed_sum > 0:
+                raise HTTPException(
+                    status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+                    detail="ZIP compression ratio too high",
+                )
+            if compressed_sum > 0:
+                ratio = uncompressed_sum / compressed_sum
+                if ratio > MAX_ZIP_RATIO:
+                    raise HTTPException(
+                        status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+                        detail="ZIP compression ratio too high",
+                    )
+            allowed_ext = {".npy", ".png", ".jpg", ".jpeg"}
+            for m in members:
+                ext = os.path.splitext(m.filename)[1].lower()
+                if ext not in allowed_ext:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail="Invalid file type in ZIP",
+                    )
+    except zipfile.BadZipFile as exc:
+        raise HTTPException(status_code=400, detail="Invalid ZIP file") from exc
+
+    frames = frames_from_zip_bytes(data)
     if len(frames) < 2:
         raise HTTPException(
             status_code=400, detail="Need >=2 frames in ZIP (.npy or images)."

--- a/server/routes/cv_analyze.py
+++ b/server/routes/cv_analyze.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-import os
-
 import io
+import os
 import zipfile
 
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
@@ -15,9 +14,7 @@ from server.config import MAX_ZIP_FILES, MAX_ZIP_RATIO, MAX_ZIP_SIZE_BYTES
 from server.security import require_api_key
 from server.storage.runs import save_run
 
-router = APIRouter(
-    prefix="/cv", tags=["cv"], dependencies=[Depends(require_api_key)]
-)
+router = APIRouter(prefix="/cv", tags=["cv"], dependencies=[Depends(require_api_key)])
 
 
 class AnalyzeQuery(BaseModel):

--- a/server/routes/cv_mock.py
+++ b/server/routes/cv_mock.py
@@ -11,8 +11,8 @@ from cv_engine.impact.detector import ImpactDetector
 from cv_engine.metrics.kinematics import CalibrationParams
 from cv_engine.metrics.quality import confidence as quality_confidence
 from cv_engine.pipeline.analyze import analyze_frames
-from server.storage.runs import save_run
 from server.security import require_api_key
+from server.storage.runs import save_run
 
 router = APIRouter(
     prefix="/cv/mock", tags=["cv-mock"], dependencies=[Depends(require_api_key)]

--- a/server/routes/runs.py
+++ b/server/routes/runs.py
@@ -5,8 +5,8 @@ from typing import List
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
-from ..storage.runs import RunRecord, delete_run, list_runs, load_run
 from ..security import require_api_key
+from ..storage.runs import RunRecord, delete_run, list_runs, load_run
 
 router = APIRouter(
     prefix="/runs", tags=["runs"], dependencies=[Depends(require_api_key)]

--- a/server/routes/runs.py
+++ b/server/routes/runs.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 from typing import List
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
 from ..storage.runs import RunRecord, delete_run, list_runs, load_run
+from ..security import require_api_key
 
-router = APIRouter(prefix="/runs", tags=["runs"])
+router = APIRouter(
+    prefix="/runs", tags=["runs"], dependencies=[Depends(require_api_key)]
+)
 
 
 class RunListItem(BaseModel):

--- a/server/security.py
+++ b/server/security.py
@@ -1,0 +1,18 @@
+"""Security helpers for API authentication."""
+from __future__ import annotations
+
+import os
+
+from fastapi import Header, HTTPException, status
+
+
+def require_api_key(x_api_key: str | None = Header(default=None)) -> None:
+    """Require a matching API key header when enabled via env."""
+    if os.getenv("REQUIRE_API_KEY", "0") != "1":
+        return
+    expected = os.getenv("API_KEY")
+    if not expected or x_api_key != expected:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="invalid api key",
+        )

--- a/server/security.py
+++ b/server/security.py
@@ -1,4 +1,5 @@
 """Security helpers for API authentication."""
+
 from __future__ import annotations
 
 import os

--- a/server/tests/test_config_env.py
+++ b/server/tests/test_config_env.py
@@ -1,0 +1,33 @@
+import importlib
+import sys
+
+
+def test_int_env_defaults_when_missing(monkeypatch):
+    monkeypatch.delenv("MAX_ZIP_FILES", raising=False)
+    sys.modules.pop("server.config", None)
+    config = importlib.import_module("server.config")
+    assert config.MAX_ZIP_FILES == 400
+
+
+def test_env_parsing_handles_invalid(monkeypatch):
+    monkeypatch.setenv("MAX_ZIP_SIZE_BYTES", "not-an-int")
+    monkeypatch.setenv("MAX_ZIP_RATIO", "not-a-float")
+    sys.modules.pop("server.config", None)
+    config = importlib.import_module("server.config")
+    assert config.MAX_ZIP_SIZE_BYTES == 50_000_000
+    assert config.MAX_ZIP_RATIO == 200.0
+
+
+def test_env_parsing_accepts_valid_values(monkeypatch):
+    monkeypatch.setenv("MAX_VIDEO_BYTES", "123456")
+    monkeypatch.setenv("MAX_ZIP_FILES", "42")
+    sys.modules.pop("server.config", None)
+    config = importlib.import_module("server.config")
+    assert config.MAX_VIDEO_BYTES == 123456
+    assert config.MAX_ZIP_FILES == 42
+
+
+def teardown_module(module):  # noqa: D401 - test cleanup helper
+    """Reset server.config module state between tests."""
+
+    sys.modules.pop("server.config", None)

--- a/server/tests/test_mock_motion_request_scoped.py
+++ b/server/tests/test_mock_motion_request_scoped.py
@@ -1,0 +1,28 @@
+from fastapi.testclient import TestClient
+
+from server.app import app
+
+
+def test_mock_motion_scoped_per_request():
+    with TestClient(app) as client:
+        req_one = {
+            "mode": "detector",
+            "ball_dx_px": 2.0,
+            "ball_dy_px": -1.0,
+            "club_dx_px": 1.5,
+            "club_dy_px": 0.0,
+        }
+        first = client.post("/cv/mock/analyze", json=req_one)
+        assert first.status_code == 200
+        req_two = {
+            "mode": "detector",
+            "ball_dx_px": 4.0,
+            "ball_dy_px": -2.5,
+            "club_dx_px": 3.0,
+            "club_dy_px": -1.0,
+        }
+        second = client.post("/cv/mock/analyze", json=req_two)
+        assert second.status_code == 200
+    metrics_one = first.json()["metrics"]
+    metrics_two = second.json()["metrics"]
+    assert metrics_one["ball_speed_mps"] != metrics_two["ball_speed_mps"]

--- a/server/tests/test_security_api_key.py
+++ b/server/tests/test_security_api_key.py
@@ -1,0 +1,13 @@
+from fastapi.testclient import TestClient
+
+from server.app import app
+
+
+def test_api_key_guard(monkeypatch):
+    monkeypatch.setenv("REQUIRE_API_KEY", "1")
+    monkeypatch.setenv("API_KEY", "s3cret")
+    with TestClient(app) as client:
+        resp = client.post("/cv/mock/analyze", json={})
+        assert resp.status_code == 401
+        ok = client.post("/cv/mock/analyze", json={}, headers={"x-api-key": "s3cret"})
+        assert ok.status_code == 200

--- a/server/tests/test_security_api_key.py
+++ b/server/tests/test_security_api_key.py
@@ -11,3 +11,11 @@ def test_api_key_guard(monkeypatch):
         assert resp.status_code == 401
         ok = client.post("/cv/mock/analyze", json={}, headers={"x-api-key": "s3cret"})
         assert ok.status_code == 200
+
+
+def test_api_key_guard_disabled(monkeypatch):
+    monkeypatch.setenv("API_KEY", "any")
+    monkeypatch.delenv("REQUIRE_API_KEY", raising=False)
+    from server.security import require_api_key
+
+    require_api_key(x_api_key=None)

--- a/server/tests/test_video_limit.py
+++ b/server/tests/test_video_limit.py
@@ -1,0 +1,14 @@
+from fastapi.testclient import TestClient
+
+from server.app import app
+from server.routes import cv_analyze_video
+
+
+def test_video_size_guard(monkeypatch):
+    monkeypatch.setattr(cv_analyze_video, "MAX_VIDEO_BYTES", 1024)
+    payload = {}
+    video_bytes = b"0" * 2048
+    with TestClient(app) as client:
+        files = {"video": ("clip.mp4", video_bytes, "video/mp4")}
+        response = client.post("/cv/analyze/video", data=payload, files=files)
+    assert response.status_code == 413

--- a/server/tests/test_zip_limits.py
+++ b/server/tests/test_zip_limits.py
@@ -7,11 +7,13 @@ from server.app import app
 from server.routes import cv_analyze
 
 
-def _zip_with_files(count: int) -> bytes:
+def _zip_with_files(count: int, *, filename: str | None = None, payload: bytes | None = None) -> bytes:
     buf = BytesIO()
     with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
         for i in range(count):
-            zf.writestr(f"{i:03d}.npy", b"0" * 10)
+            name = filename or f"{i:03d}.npy"
+            data = payload if payload is not None else b"0" * 10
+            zf.writestr(name, data)
     buf.seek(0)
     return buf.getvalue()
 
@@ -21,6 +23,39 @@ def test_zip_file_count_limit(monkeypatch):
     monkeypatch.setattr(cv_analyze, "MAX_ZIP_RATIO", 10_000)
     monkeypatch.setattr(cv_analyze, "MAX_ZIP_SIZE_BYTES", 1_000_000)
     data = _zip_with_files(2)
+    with TestClient(app) as client:
+        files = {"frames_zip": ("frames.zip", data, "application/zip")}
+        response = client.post("/cv/analyze", data={}, files=files)
+    assert response.status_code == 413
+
+
+def test_zip_ratio_limit(monkeypatch):
+    monkeypatch.setattr(cv_analyze, "MAX_ZIP_FILES", 10)
+    monkeypatch.setattr(cv_analyze, "MAX_ZIP_RATIO", 2)
+    monkeypatch.setattr(cv_analyze, "MAX_ZIP_SIZE_BYTES", 1_000_000)
+    data = _zip_with_files(1, payload=b"0" * 10_000)
+    with TestClient(app) as client:
+        files = {"frames_zip": ("frames.zip", data, "application/zip")}
+        response = client.post("/cv/analyze", data={}, files=files)
+    assert response.status_code == 413
+
+
+def test_zip_invalid_extension(monkeypatch):
+    monkeypatch.setattr(cv_analyze, "MAX_ZIP_FILES", 10)
+    monkeypatch.setattr(cv_analyze, "MAX_ZIP_RATIO", 10_000)
+    monkeypatch.setattr(cv_analyze, "MAX_ZIP_SIZE_BYTES", 1_000_000)
+    data = _zip_with_files(1, filename="bad.txt", payload=b"oops")
+    with TestClient(app) as client:
+        files = {"frames_zip": ("frames.zip", data, "application/zip")}
+        response = client.post("/cv/analyze", data={}, files=files)
+    assert response.status_code == 400
+
+
+def test_zip_rejects_large_member(monkeypatch):
+    monkeypatch.setattr(cv_analyze, "MAX_ZIP_FILES", 10)
+    monkeypatch.setattr(cv_analyze, "MAX_ZIP_RATIO", 10_000)
+    monkeypatch.setattr(cv_analyze, "MAX_ZIP_SIZE_BYTES", 100)
+    data = _zip_with_files(1, payload=b"0" * 200)
     with TestClient(app) as client:
         files = {"frames_zip": ("frames.zip", data, "application/zip")}
         response = client.post("/cv/analyze", data={}, files=files)

--- a/server/tests/test_zip_limits.py
+++ b/server/tests/test_zip_limits.py
@@ -1,0 +1,27 @@
+from io import BytesIO
+import zipfile
+
+from fastapi.testclient import TestClient
+
+from server.app import app
+from server.routes import cv_analyze
+
+
+def _zip_with_files(count: int) -> bytes:
+    buf = BytesIO()
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for i in range(count):
+            zf.writestr(f"{i:03d}.npy", b"0" * 10)
+    buf.seek(0)
+    return buf.getvalue()
+
+
+def test_zip_file_count_limit(monkeypatch):
+    monkeypatch.setattr(cv_analyze, "MAX_ZIP_FILES", 1)
+    monkeypatch.setattr(cv_analyze, "MAX_ZIP_RATIO", 10_000)
+    monkeypatch.setattr(cv_analyze, "MAX_ZIP_SIZE_BYTES", 1_000_000)
+    data = _zip_with_files(2)
+    with TestClient(app) as client:
+        files = {"frames_zip": ("frames.zip", data, "application/zip")}
+        response = client.post("/cv/analyze", data={}, files=files)
+    assert response.status_code == 413

--- a/server/tests/test_zip_limits.py
+++ b/server/tests/test_zip_limits.py
@@ -1,5 +1,5 @@
-from io import BytesIO
 import zipfile
+from io import BytesIO
 
 from fastapi.testclient import TestClient
 


### PR DESCRIPTION
## Summary
- enforce optional API key guard on CV and run routers with shared dependency
- add configurable ZIP/video upload limits and compression checks for bomb protection
- make mock YOLO motion parameters request-scoped and document new security and limit settings

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd62d45fe8832687531fddf63d44f2