### PR TITLE
feat(cv): single-pass detections + smoothing_window + robust velocity

### DIFF
--- a/cv_engine/calibration/simple.py
+++ b/cv_engine/calibration/simple.py
@@ -4,7 +4,7 @@ import math
 from dataclasses import dataclass
 from typing import Iterable, Tuple
 
-from cv_engine.metrics.kinematics import CalibrationParams
+from cv_engine.metrics.kinematics import CalibrationParams, velocity_avg
 
 
 @dataclass
@@ -21,16 +21,7 @@ def _velocity(
     track: Iterable[Tuple[float, float]], calib: CalibrationParams
 ) -> Tuple[float, float]:
     """Compute velocity components (vx, vy) in m/s from a track."""
-    points = list(track)
-    if len(points) < 2:
-        return 0.0, 0.0
-    (x1, y1), (x2, y2) = points[0], points[1]
-    dx = (x2 - x1) * calib.m_per_px
-    dy = (y2 - y1) * calib.m_per_px
-    dy = -dy  # invert because image y increases downward
-    vx = dx * calib.fps
-    vy = dy * calib.fps
-    return vx, vy
+    return velocity_avg(track, calib.fps, calib.m_per_px)
 
 
 def measure_from_tracks(ball, club, calib: CalibrationParams) -> KinematicMetrics:

--- a/cv_engine/metrics/kinematics.py
+++ b/cv_engine/metrics/kinematics.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Iterable, Sequence, Tuple
 
 
 @dataclass
@@ -15,3 +16,46 @@ class CalibrationParams:
         cls, ref_len_m: float, ref_len_px: float, fps: float
     ) -> "CalibrationParams":
         return cls(m_per_px=ref_len_m / ref_len_px, fps=fps)
+
+
+Point = Tuple[float, float]
+
+
+def _two_point_velocity(
+    positions_px: Sequence[Point], fps: float, m_per_px: float
+) -> Tuple[float, float]:
+    if len(positions_px) < 2:
+        return 0.0, 0.0
+    (x1, y1), (x2, y2) = positions_px[0], positions_px[1]
+    dx = (x2 - x1) * m_per_px
+    dy = (y2 - y1) * m_per_px
+    dy = -dy
+    vx = dx * fps
+    vy = dy * fps
+    return vx, vy
+
+
+def velocity_avg(
+    positions_px: Iterable[Point], fps: float, m_per_px: float
+) -> Tuple[float, float]:
+    """Compute average velocity across a track."""
+
+    pts = list(positions_px)
+    if len(pts) < 3:
+        return _two_point_velocity(pts, fps, m_per_px)
+
+    vx_total = 0.0
+    vy_total = 0.0
+    steps = 0
+    for (x1, y1), (x2, y2) in zip(pts[:-1], pts[1:]):
+        dx = (x2 - x1) * m_per_px
+        dy = (y2 - y1) * m_per_px
+        dy = -dy
+        vx_total += dx * fps
+        vy_total += dy * fps
+        steps += 1
+
+    if steps == 0:
+        return 0.0, 0.0
+
+    return vx_total / steps, vy_total / steps

--- a/cv_engine/tests/test_pipeline_single_pass.py
+++ b/cv_engine/tests/test_pipeline_single_pass.py
@@ -1,0 +1,21 @@
+import numpy as np
+
+from cv_engine.metrics.kinematics import CalibrationParams
+from cv_engine.pipeline.analyze import analyze_frames
+
+
+def test_single_pass_detector(monkeypatch):
+    frames = [np.zeros((32, 32, 3), dtype=np.uint8) for _ in range(6)]
+    calib = CalibrationParams.from_reference(1.0, 100.0, 120.0)
+
+    call_counter = {"count": 0}
+
+    def fake_run(self, frame):
+        call_counter["count"] += 1
+        return []
+
+    monkeypatch.setattr("cv_engine.inference.yolo8.YoloV8Detector.run", fake_run)
+
+    analyze_frames(frames, calib)
+
+    assert call_counter["count"] == len(frames)

--- a/cv_engine/tests/test_smoothing_window_effect.py
+++ b/cv_engine/tests/test_smoothing_window_effect.py
@@ -1,0 +1,68 @@
+import math
+
+import numpy as np
+
+from cv_engine.calibration.simple import as_dict, measure_from_tracks
+from cv_engine.metrics.kinematics import CalibrationParams
+from cv_engine.pipeline.analyze import analyze_frames
+from cv_engine.types import Box
+
+
+def _box_from_center(cx: float, cy: float, label: str) -> Box:
+    half = 2
+    return Box(
+        int(cx - half),
+        int(cy - half),
+        int(cx + half),
+        int(cy + half),
+        label,
+        0.9,
+    )
+
+
+def test_smoothing_window_reduces_metric_error(monkeypatch):
+    fps = 120.0
+    calib = CalibrationParams.from_reference(1.0, 100.0, fps)
+    frames = [np.zeros((64, 64, 3), dtype=np.uint8) for _ in range(10)]
+
+    base_ball = [(20 + i * 2.0, 40 - i * 1.0) for i in range(len(frames))]
+    base_club = [(10 + i * 1.5, 50 - i * 0.2) for i in range(len(frames))]
+
+    jitter = 4.0
+    noisy_ball = [
+        (x, y + ((-1) ** i) * jitter)
+        for i, (x, y) in enumerate(base_ball)
+    ]
+    noisy_club = [
+        (x, y + ((-1) ** i) * (jitter / 2))
+        for i, (x, y) in enumerate(base_club)
+    ]
+
+    state = {"idx": 0}
+
+    def fake_run(self, frame):
+        idx = state["idx"]
+        state["idx"] += 1
+        return [
+            _box_from_center(*noisy_ball[idx], "ball"),
+            _box_from_center(*noisy_club[idx], "club"),
+        ]
+
+    monkeypatch.setattr("cv_engine.inference.yolo8.YoloV8Detector.run", fake_run)
+
+    baseline = as_dict(measure_from_tracks(base_ball, base_club, calib))
+
+    state["idx"] = 0
+    unsmoothed = analyze_frames(frames, calib, smoothing_window=1)["metrics"]
+    state["idx"] = 0
+    smoothed = analyze_frames(frames, calib, smoothing_window=5)["metrics"]
+
+    assert math.isfinite(unsmoothed["launch_deg"])
+    assert math.isfinite(smoothed["launch_deg"])
+
+    assert abs(smoothed["ball_speed_mps"] - baseline["ball_speed_mps"]) < abs(
+        unsmoothed["ball_speed_mps"] - baseline["ball_speed_mps"]
+    )
+    assert abs(smoothed["launch_deg"] - baseline["launch_deg"]) < abs(
+        unsmoothed["launch_deg"] - baseline["launch_deg"]
+    )

--- a/cv_engine/tests/test_smoothing_window_effect.py
+++ b/cv_engine/tests/test_smoothing_window_effect.py
@@ -29,13 +29,9 @@ def test_smoothing_window_reduces_metric_error(monkeypatch):
     base_club = [(10 + i * 1.5, 50 - i * 0.2) for i in range(len(frames))]
 
     jitter = 4.0
-    noisy_ball = [
-        (x, y + ((-1) ** i) * jitter)
-        for i, (x, y) in enumerate(base_ball)
-    ]
+    noisy_ball = [(x, y + ((-1) ** i) * jitter) for i, (x, y) in enumerate(base_ball)]
     noisy_club = [
-        (x, y + ((-1) ** i) * (jitter / 2))
-        for i, (x, y) in enumerate(base_club)
+        (x, y + ((-1) ** i) * (jitter / 2)) for i, (x, y) in enumerate(base_club)
     ]
 
     state = {"idx": 0}

--- a/cv_engine/tests/test_velocity_avg.py
+++ b/cv_engine/tests/test_velocity_avg.py
@@ -1,0 +1,46 @@
+import math
+
+from cv_engine.metrics.kinematics import velocity_avg
+
+
+def _two_point(track, fps, m_per_px):
+    if len(track) < 2:
+        return (0.0, 0.0)
+    (x1, y1), (x2, y2) = track[0], track[1]
+    dx = (x2 - x1) * m_per_px
+    dy = (y2 - y1) * m_per_px
+    return dx * fps, -dy * fps
+
+
+def test_velocity_avg_reduces_error_with_noise():
+    fps = 120.0
+    m_per_px = 0.01
+    vx_true = 5.0
+    vy_true = 2.0
+    frames = 10
+    dx_px = vx_true / (fps * m_per_px)
+    dy_px = vy_true / (fps * m_per_px)
+
+    track = []
+    for i in range(frames):
+        noise_x = (-1) ** i * 0.3
+        noise_y = (-1) ** (i + 1) * 0.4
+        x = 50 + i * dx_px + noise_x
+        y = 40 - i * dy_px + noise_y
+        track.append((x, y))
+
+    vx_avg, vy_avg = velocity_avg(track, fps, m_per_px)
+    vx_two, vy_two = _two_point(track, fps, m_per_px)
+
+    err_avg = math.hypot(vx_avg - vx_true, vy_avg - vy_true)
+    err_two = math.hypot(vx_two - vx_true, vy_two - vy_true)
+
+    assert err_avg <= err_two + 1e-6
+
+
+def test_velocity_avg_matches_two_point_for_short_tracks():
+    fps = 120.0
+    m_per_px = 0.01
+    track = [(0.0, 0.0), (1.0, 1.0)]
+    assert velocity_avg(track[:1], fps, m_per_px) == (0.0, 0.0)
+    assert velocity_avg(track, fps, m_per_px) == _two_point(track, fps, m_per_px)

--- a/server/routes/cv_analyze.py
+++ b/server/routes/cv_analyze.py
@@ -18,6 +18,7 @@ class AnalyzeQuery(BaseModel):
     ref_len_m: float = Field(1.0, gt=0)
     ref_len_px: float = Field(100.0, gt=0)
     mode: str = "detector"  # "detector" | "tracks" ( tracks ej stödd här )
+    smoothing_window: int = 3
     persist: bool = False
     run_name: str | None = None
 
@@ -44,7 +45,9 @@ async def analyze(
     calib = CalibrationParams.from_reference(
         query.ref_len_m, query.ref_len_px, query.fps
     )
-    result = analyze_frames(frames, calib)  # använder detektor + vår pipeline
+    result = analyze_frames(
+        frames, calib, smoothing_window=query.smoothing_window
+    )  # använder detektor + vår pipeline
     events = result["events"]
     metrics = result["metrics"]
     if "confidence" not in metrics:

--- a/server/routes/cv_analyze_video.py
+++ b/server/routes/cv_analyze_video.py
@@ -61,7 +61,7 @@ async def analyze_video(
 
     fps = fps_from_video(data) or float(query.fps_fallback)
     calib = CalibrationParams.from_reference(query.ref_len_m, query.ref_len_px, fps)
-    result = analyze_frames(frames, calib)
+    result = analyze_frames(frames, calib, smoothing_window=query.smoothing_window)
     events = result["events"]
     metrics = result["metrics"]
     if "confidence" not in metrics:


### PR DESCRIPTION
## Summary
- run YOLO once per frame in the CV pipeline, reuse cached boxes for impact detection, and add optional smoothing of tracks
- introduce an averaged velocity helper for track-based kinematics and use it in calibration
- expose the smoothing window through the API and cover the new behavior with focused tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd63022bfc8326b4c36f44c10f94d7