### PR TITLE
Use shared require_api_key dependency

### DIFF
--- a/server/security.py
+++ b/server/security.py
@@ -1,0 +1,24 @@
+"""Shared security helpers for FastAPI apps."""
+
+import os
+
+from fastapi import HTTPException, Request, status
+
+
+async def require_api_key(request: Request) -> None:
+    """Validate that the incoming request provides the configured API key.
+
+    If no ``API_KEY`` environment variable is configured the dependency is a
+    no-op, allowing routes to stay open by default. When an API key is set and
+    the provided header does not match, a 401 error is raised.
+    """
+
+    required = os.getenv("API_KEY")
+    if not required:
+        return
+
+    provided = request.headers.get("x-api-key")
+    if provided != required:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid api key"
+        )

--- a/server/tests/test_health_api.py
+++ b/server/tests/test_health_api.py
@@ -23,7 +23,9 @@ def test_protected_requires_api_key_when_set(monkeypatch):
     protected_route = next(
         r for r in app.routes if isinstance(r, APIRoute) and r.path == "/protected"
     )
-    assert any(dep.dependency is require_api_key for dep in protected_route.dependencies)
+    assert any(
+        dep.dependency is require_api_key for dep in protected_route.dependencies
+    )
 
     with TestClient(app) as client:
         assert client.get("/protected").status_code in (401, 403)

--- a/server/tests/test_health_api.py
+++ b/server/tests/test_health_api.py
@@ -3,9 +3,11 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[2]))
 
+from fastapi.routing import APIRoute  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 
 from server_app import app  # noqa: E402
+from server.security import require_api_key  # noqa: E402
 
 
 def test_health_ok():
@@ -17,6 +19,12 @@ def test_health_ok():
 
 def test_protected_requires_api_key_when_set(monkeypatch):
     monkeypatch.setenv("API_KEY", "secret")
+
+    protected_route = next(
+        r for r in app.routes if isinstance(r, APIRoute) and r.path == "/protected"
+    )
+    assert any(dep.dependency is require_api_key for dep in protected_route.dependencies)
+
     with TestClient(app) as client:
         assert client.get("/protected").status_code in (401, 403)
         assert (


### PR DESCRIPTION
## Summary
- add a shared `server.security.require_api_key` FastAPI dependency for API key checks
- use the shared dependency in the main API app and the fallback server shim
- update the health API test to assert the shared helper is wired into protected routes

## Testing
- pytest server/tests/test_health_api.py server/tests/test_auth_default_open.py


------
https://chatgpt.com/codex/tasks/task_e_68cda4944f008326a8caab07a9abc12b