### PR TITLE
chore(security): apply API key guard and upload limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ When `SERVE_WEB=1` the FastAPI server mounts the compiled SPA from `web/dist` an
 
 The UI currently calls the following endpoints: `/cv/mock/analyze`, `/cv/analyze`, `/cv/analyze/video`, and `/runs` (including `/runs/{id}` and `DELETE /runs/{id}`).
 
+## Security & limits
+
+* Set `REQUIRE_API_KEY=1` to require the header `x-api-key` to match `API_KEY` for analysis and runs endpoints.
+* Uploads are bounded by defaults: ZIPs ≤ 50 MB, ≤ 400 files, compression ratio ≤ 200×, and videos ≤ 80 MB. Override with `MAX_ZIP_SIZE_BYTES`, `MAX_ZIP_FILES`, `MAX_ZIP_RATIO`, or `MAX_VIDEO_BYTES`.
+
 ## Web UI
 
 The project ships with a Vite + React single-page app for uploading captures, kicking off mock runs, and browsing persisted runs.

--- a/server/config.py
+++ b/server/config.py
@@ -1,0 +1,31 @@
+"""Configuration helpers for server constants."""
+
+from __future__ import annotations
+
+import os
+
+
+def _int_env(name: str, default: int) -> int:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        return default
+
+
+def _float_env(name: str, default: float) -> float:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except ValueError:
+        return default
+
+
+MAX_ZIP_SIZE_BYTES: int = _int_env("MAX_ZIP_SIZE_BYTES", 50_000_000)
+MAX_ZIP_FILES: int = _int_env("MAX_ZIP_FILES", 400)
+MAX_ZIP_RATIO: float = _float_env("MAX_ZIP_RATIO", 200.0)
+MAX_VIDEO_BYTES: int = _int_env("MAX_VIDEO_BYTES", 80_000_000)

--- a/server/routes/cv_analyze_video.py
+++ b/server/routes/cv_analyze_video.py
@@ -1,14 +1,20 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, File, Form, HTTPException, UploadFile
+from tempfile import SpooledTemporaryFile
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
 from pydantic import BaseModel, Field
 
 from cv_engine.io.videoreader import fps_from_video, frames_from_video
 from cv_engine.metrics.kinematics import CalibrationParams
 from cv_engine.pipeline.analyze import analyze_frames
+from server.config import MAX_VIDEO_BYTES
+from server.security import require_api_key
 from server.storage.runs import save_run
 
-router = APIRouter(prefix="/cv", tags=["cv-video"])
+router = APIRouter(
+    prefix="/cv", tags=["cv-video"], dependencies=[Depends(require_api_key)]
+)
 
 
 class AnalyzeVideoQuery(BaseModel):
@@ -45,7 +51,33 @@ async def analyze_video(
         persist=persist,
         run_name=run_name,
     )
-    data = await video.read()
+    header_len = video.headers.get("content-length")
+    if header_len:
+        try:
+            if int(header_len) > MAX_VIDEO_BYTES:
+                raise HTTPException(
+                    status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+                    detail="Video too large",
+                )
+        except ValueError:
+            pass
+
+    with SpooledTemporaryFile(max_size=MAX_VIDEO_BYTES) as tmp:
+        total = 0
+        chunk_size = 1024 * 1024
+        while True:
+            chunk = await video.read(chunk_size)
+            if not chunk:
+                break
+            total += len(chunk)
+            if total > MAX_VIDEO_BYTES:
+                raise HTTPException(
+                    status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+                    detail="Video too large",
+                )
+            tmp.write(chunk)
+        tmp.seek(0)
+        data = tmp.read()
     try:
         frames = frames_from_video(data, max_frames=300, stride=1)
     except ImportError:

--- a/server/routes/cv_mock.py
+++ b/server/routes/cv_mock.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import numpy as np
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 from pydantic import BaseModel, Field
 
 from cv_engine.calibration.simple import as_dict, measure_from_tracks
@@ -9,9 +9,12 @@ from cv_engine.impact.detector import ImpactDetector
 from cv_engine.metrics.kinematics import CalibrationParams
 from cv_engine.metrics.quality import confidence as quality_confidence
 from cv_engine.pipeline.analyze import analyze_frames
+from server.security import require_api_key
 from server.storage.runs import save_run
 
-router = APIRouter(prefix="/cv/mock", tags=["cv-mock"])
+router = APIRouter(
+    prefix="/cv/mock", tags=["cv-mock"], dependencies=[Depends(require_api_key)]
+)
 
 
 class AnalyzeRequest(BaseModel):

--- a/server/routes/runs.py
+++ b/server/routes/runs.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 from typing import List
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
+from ..security import require_api_key
 from ..storage.runs import RunRecord, delete_run, list_runs, load_run
 
-router = APIRouter(prefix="/runs", tags=["runs"])
+router = APIRouter(
+    prefix="/runs", tags=["runs"], dependencies=[Depends(require_api_key)]
+)
 
 
 class RunListItem(BaseModel):

--- a/server/security.py
+++ b/server/security.py
@@ -1,0 +1,19 @@
+"""Security helpers for API authentication."""
+
+from __future__ import annotations
+
+import os
+
+from fastapi import Header, HTTPException, status
+
+
+def require_api_key(x_api_key: str | None = Header(default=None)) -> None:
+    """Require a matching API key header when enabled via env."""
+    if os.getenv("REQUIRE_API_KEY", "0") != "1":
+        return
+    expected = os.getenv("API_KEY")
+    if not expected or x_api_key != expected:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="invalid api key",
+        )

--- a/server/tests/test_config_env.py
+++ b/server/tests/test_config_env.py
@@ -1,0 +1,33 @@
+import importlib
+import sys
+
+
+def test_int_env_defaults_when_missing(monkeypatch):
+    monkeypatch.delenv("MAX_ZIP_FILES", raising=False)
+    sys.modules.pop("server.config", None)
+    config = importlib.import_module("server.config")
+    assert config.MAX_ZIP_FILES == 400
+
+
+def test_env_parsing_handles_invalid(monkeypatch):
+    monkeypatch.setenv("MAX_ZIP_SIZE_BYTES", "not-an-int")
+    monkeypatch.setenv("MAX_ZIP_RATIO", "not-a-float")
+    sys.modules.pop("server.config", None)
+    config = importlib.import_module("server.config")
+    assert config.MAX_ZIP_SIZE_BYTES == 50_000_000
+    assert config.MAX_ZIP_RATIO == 200.0
+
+
+def test_env_parsing_accepts_valid_values(monkeypatch):
+    monkeypatch.setenv("MAX_VIDEO_BYTES", "123456")
+    monkeypatch.setenv("MAX_ZIP_FILES", "42")
+    sys.modules.pop("server.config", None)
+    config = importlib.import_module("server.config")
+    assert config.MAX_VIDEO_BYTES == 123456
+    assert config.MAX_ZIP_FILES == 42
+
+
+def teardown_module(module):  # noqa: D401 - test cleanup helper
+    """Reset server.config module state between tests."""
+
+    sys.modules.pop("server.config", None)

--- a/server/tests/test_security_api_key.py
+++ b/server/tests/test_security_api_key.py
@@ -1,0 +1,21 @@
+from fastapi.testclient import TestClient
+
+from server.app import app
+
+
+def test_api_key_guard(monkeypatch):
+    monkeypatch.setenv("REQUIRE_API_KEY", "1")
+    monkeypatch.setenv("API_KEY", "s3cret")
+    with TestClient(app) as client:
+        resp = client.post("/cv/mock/analyze", json={})
+        assert resp.status_code == 401
+        ok = client.post("/cv/mock/analyze", json={}, headers={"x-api-key": "s3cret"})
+        assert ok.status_code == 200
+
+
+def test_api_key_guard_disabled(monkeypatch):
+    monkeypatch.setenv("API_KEY", "any")
+    monkeypatch.delenv("REQUIRE_API_KEY", raising=False)
+    from server.security import require_api_key
+
+    require_api_key(x_api_key=None)

--- a/server/tests/test_video_limit.py
+++ b/server/tests/test_video_limit.py
@@ -12,3 +12,99 @@ def test_video_size_guard(monkeypatch):
         files = {"video": ("clip.mp4", video_bytes, "video/mp4")}
         response = client.post("/cv/analyze/video", data=payload, files=files)
     assert response.status_code == 413
+
+
+def test_video_header_length_guard(monkeypatch):
+    monkeypatch.setattr(cv_analyze_video, "MAX_VIDEO_BYTES", 100)
+    payload = {}
+    video_bytes = b"0" * 10
+    with TestClient(app) as client:
+        files = {
+            "video": (
+                "clip.mp4",
+                video_bytes,
+                "video/mp4",
+                {"Content-Length": "250"},
+            )
+        }
+        response = client.post("/cv/analyze/video", data=payload, files=files)
+    assert response.status_code == 413
+
+
+def test_video_import_error(monkeypatch):
+    monkeypatch.setattr(cv_analyze_video, "MAX_VIDEO_BYTES", 1024)
+
+    def fake_frames(_, **__):
+        raise ImportError("no video support")
+
+    monkeypatch.setattr(cv_analyze_video, "frames_from_video", fake_frames)
+    payload = {}
+    video_bytes = b"0" * 10
+    with TestClient(app) as client:
+        files = {"video": ("clip.mp4", video_bytes, "video/mp4")}
+        response = client.post("/cv/analyze/video", data=payload, files=files)
+    assert response.status_code == 400
+
+
+def test_video_requires_multiple_frames(monkeypatch):
+    monkeypatch.setattr(cv_analyze_video, "MAX_VIDEO_BYTES", 1024)
+
+    def fake_frames(_, **__):
+        return [object()]
+
+    monkeypatch.setattr(cv_analyze_video, "frames_from_video", fake_frames)
+    payload = {}
+    video_bytes = b"0" * 10
+    with TestClient(app) as client:
+        files = {"video": ("clip.mp4", video_bytes, "video/mp4")}
+        response = client.post("/cv/analyze/video", data=payload, files=files)
+    assert response.status_code == 400
+
+
+def test_video_persist_adds_confidence(monkeypatch):
+    monkeypatch.setattr(cv_analyze_video, "MAX_VIDEO_BYTES", 1_000_000)
+
+    def fake_frames(_, **__):
+        return [object(), object(), object()]
+
+    def fake_fps(_):
+        return None
+
+    def fake_analyze(frames, calib, *, mock=True, smoothing_window):
+        assert mock is True
+        assert smoothing_window == 3
+        return {"events": [42], "metrics": {}}
+
+    class DummyRun:
+        run_id = "vid-456"
+
+    captured: dict = {}
+
+    def fake_save_run(**kwargs):
+        captured.update(kwargs)
+        return DummyRun()
+
+    monkeypatch.setattr(cv_analyze_video, "frames_from_video", fake_frames)
+    monkeypatch.setattr(cv_analyze_video, "fps_from_video", fake_fps)
+    monkeypatch.setattr(cv_analyze_video, "analyze_frames", fake_analyze)
+    monkeypatch.setattr(cv_analyze_video, "save_run", fake_save_run)
+
+    payload = {"persist": "true", "fps_fallback": "144"}
+    video_bytes = b"0123456789"
+    with TestClient(app) as client:
+        files = {
+            "video": (
+                "clip.mp4",
+                video_bytes,
+                "video/mp4",
+                {"Content-Length": "not-an-int"},
+            )
+        }
+        response = client.post("/cv/analyze/video", data=payload, files=files)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["run_id"] == "vid-456"
+    assert body["metrics"]["confidence"] == 0.0
+    assert captured["source"] == "video"
+    assert captured["params"]["fps_fallback"] == 144.0

--- a/server/tests/test_video_limit.py
+++ b/server/tests/test_video_limit.py
@@ -1,0 +1,14 @@
+from fastapi.testclient import TestClient
+
+from server.app import app
+from server.routes import cv_analyze_video
+
+
+def test_video_size_guard(monkeypatch):
+    monkeypatch.setattr(cv_analyze_video, "MAX_VIDEO_BYTES", 1024)
+    payload = {}
+    video_bytes = b"0" * 2048
+    with TestClient(app) as client:
+        files = {"video": ("clip.mp4", video_bytes, "video/mp4")}
+        response = client.post("/cv/analyze/video", data=payload, files=files)
+    assert response.status_code == 413

--- a/server/tests/test_zip_limits.py
+++ b/server/tests/test_zip_limits.py
@@ -1,0 +1,64 @@
+import zipfile
+from io import BytesIO
+
+from fastapi.testclient import TestClient
+
+from server.app import app
+from server.routes import cv_analyze
+
+
+def _zip_with_files(
+    count: int, *, filename: str | None = None, payload: bytes | None = None
+) -> bytes:
+    buf = BytesIO()
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for i in range(count):
+            name = filename or f"{i:03d}.npy"
+            data = payload if payload is not None else b"0" * 10
+            zf.writestr(name, data)
+    buf.seek(0)
+    return buf.getvalue()
+
+
+def test_zip_file_count_limit(monkeypatch):
+    monkeypatch.setattr(cv_analyze, "MAX_ZIP_FILES", 1)
+    monkeypatch.setattr(cv_analyze, "MAX_ZIP_RATIO", 10_000)
+    monkeypatch.setattr(cv_analyze, "MAX_ZIP_SIZE_BYTES", 1_000_000)
+    data = _zip_with_files(2)
+    with TestClient(app) as client:
+        files = {"frames_zip": ("frames.zip", data, "application/zip")}
+        response = client.post("/cv/analyze", data={}, files=files)
+    assert response.status_code == 413
+
+
+def test_zip_ratio_limit(monkeypatch):
+    monkeypatch.setattr(cv_analyze, "MAX_ZIP_FILES", 10)
+    monkeypatch.setattr(cv_analyze, "MAX_ZIP_RATIO", 2)
+    monkeypatch.setattr(cv_analyze, "MAX_ZIP_SIZE_BYTES", 1_000_000)
+    data = _zip_with_files(1, payload=b"0" * 10_000)
+    with TestClient(app) as client:
+        files = {"frames_zip": ("frames.zip", data, "application/zip")}
+        response = client.post("/cv/analyze", data={}, files=files)
+    assert response.status_code == 413
+
+
+def test_zip_invalid_extension(monkeypatch):
+    monkeypatch.setattr(cv_analyze, "MAX_ZIP_FILES", 10)
+    monkeypatch.setattr(cv_analyze, "MAX_ZIP_RATIO", 10_000)
+    monkeypatch.setattr(cv_analyze, "MAX_ZIP_SIZE_BYTES", 1_000_000)
+    data = _zip_with_files(1, filename="bad.txt", payload=b"oops")
+    with TestClient(app) as client:
+        files = {"frames_zip": ("frames.zip", data, "application/zip")}
+        response = client.post("/cv/analyze", data={}, files=files)
+    assert response.status_code == 400
+
+
+def test_zip_rejects_large_member(monkeypatch):
+    monkeypatch.setattr(cv_analyze, "MAX_ZIP_FILES", 10)
+    monkeypatch.setattr(cv_analyze, "MAX_ZIP_RATIO", 10_000)
+    monkeypatch.setattr(cv_analyze, "MAX_ZIP_SIZE_BYTES", 100)
+    data = _zip_with_files(1, payload=b"0" * 200)
+    with TestClient(app) as client:
+        files = {"frames_zip": ("frames.zip", data, "application/zip")}
+        response = client.post("/cv/analyze", data={}, files=files)
+    assert response.status_code == 413

--- a/server/tests/test_zip_limits.py
+++ b/server/tests/test_zip_limits.py
@@ -62,3 +62,73 @@ def test_zip_rejects_large_member(monkeypatch):
         files = {"frames_zip": ("frames.zip", data, "application/zip")}
         response = client.post("/cv/analyze", data={}, files=files)
     assert response.status_code == 413
+
+
+def test_zip_invalid_archive(monkeypatch):
+    monkeypatch.setattr(cv_analyze, "MAX_ZIP_FILES", 10)
+    monkeypatch.setattr(cv_analyze, "MAX_ZIP_RATIO", 10_000)
+    monkeypatch.setattr(cv_analyze, "MAX_ZIP_SIZE_BYTES", 1_000_000)
+    with TestClient(app) as client:
+        files = {"frames_zip": ("frames.zip", b"not-a-zip", "application/zip")}
+        response = client.post("/cv/analyze", data={}, files=files)
+    assert response.status_code == 400
+
+
+def test_zip_requires_multiple_frames(monkeypatch):
+    monkeypatch.setattr(cv_analyze, "MAX_ZIP_FILES", 10)
+    monkeypatch.setattr(cv_analyze, "MAX_ZIP_RATIO", 10_000)
+    monkeypatch.setattr(cv_analyze, "MAX_ZIP_SIZE_BYTES", 1_000_000)
+
+    def fake_frames(_: bytes):
+        return [object()]
+
+    monkeypatch.setattr(cv_analyze, "frames_from_zip_bytes", fake_frames)
+    data = _zip_with_files(1)
+    with TestClient(app) as client:
+        files = {"frames_zip": ("frames.zip", data, "application/zip")}
+        response = client.post("/cv/analyze", data={}, files=files)
+    assert response.status_code == 400
+
+
+def test_zip_persist_adds_confidence(monkeypatch):
+    monkeypatch.setattr(cv_analyze, "MAX_ZIP_FILES", 10)
+    monkeypatch.setattr(cv_analyze, "MAX_ZIP_RATIO", 10_000)
+    monkeypatch.setattr(cv_analyze, "MAX_ZIP_SIZE_BYTES", 1_000_000)
+
+    def fake_frames(_: bytes):
+        return [object(), object()]
+
+    def fake_analyze(frames, calib, *, mock=True, smoothing_window):
+        assert mock is True
+        assert smoothing_window == 3
+        return {"events": [1, 2], "metrics": {"distance": 12.3}}
+
+    class DummyRun:
+        run_id = "run-123"
+
+    captured: dict = {}
+
+    def fake_save_run(**kwargs):
+        captured.update(kwargs)
+        return DummyRun()
+
+    monkeypatch.setattr(cv_analyze, "frames_from_zip_bytes", fake_frames)
+    monkeypatch.setattr(cv_analyze, "analyze_frames", fake_analyze)
+    monkeypatch.setattr(cv_analyze, "save_run", fake_save_run)
+
+    data = _zip_with_files(2)
+    with TestClient(app) as client:
+        files = {"frames_zip": ("frames.zip", data, "application/zip")}
+        response = client.post(
+            "/cv/analyze",
+            params={"persist": "true", "run_name": "demo"},
+            data={},
+            files=files,
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["run_id"] == "run-123"
+    assert body["metrics"]["confidence"] == 0.0
+    assert captured["source"] == "zip"
+    assert captured["mode"] == "detector"


### PR DESCRIPTION
## Summary
- add a shared `require_api_key` dependency and apply it to CV and runs routers
- enforce size and compression limits for ZIP and video uploads using centralized config helpers
- document the new security toggles and cover them with unit tests

## Testing
- poetry run black .
- poetry run isort .
- poetry run flake8
- poetry run pytest


------
https://chatgpt.com/codex/tasks/task_e_68cdc7390b688326b68236f19837e5f2