### PR TITLE
feat(web): send x-api-key from VITE_API_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ npm run dev
 
 Configure the backend origin with `VITE_API_BASE` (defaults to `http://localhost:8000`).
 
+#### API-nyckel
+
+- `VITE_API_KEY` skickas som `x-api-key` från webben.
+- Dev: `VITE_API_BASE=http://localhost:8000 VITE_API_KEY=s3cret npm run dev`.
+
 ### Build & serve from FastAPI
 
 ```bash

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,9 +1,18 @@
 import axios from "axios";
 
 const API = import.meta.env.VITE_API_BASE || "http://localhost:8000";
+const API_KEY = import.meta.env.VITE_API_KEY || "";
+const headers = (extra: any = {}) =>
+  API_KEY ? { "x-api-key": API_KEY, ...extra } : extra;
 
 export const postMockAnalyze = (body: unknown) =>
-  axios.post(`${API}/cv/mock/analyze`, body).then((r) => r.data);
+  axios
+    .post(
+      `${API}/cv/mock/analyze`,
+      body,
+      { headers: headers({ "Content-Type": "application/json" }) }
+    )
+    .then((r) => r.data);
 
 export const postZipAnalyze = (
   form: FormData,
@@ -20,7 +29,7 @@ export const postZipAnalyze = (
     .post(
       `${API}/cv/analyze?fps=${q.fps}&ref_len_m=${q.ref_len_m}&ref_len_px=${q.ref_len_px}&mode=${q.mode || "detector"}&smoothing_window=${q.smoothing_window || 3}&persist=${!!q.persist}`,
       form,
-      { headers: { "Content-Type": "multipart/form-data" } }
+      { headers: headers({ "Content-Type": "multipart/form-data" }) }
     )
     .then((r) => r.data);
 
@@ -38,10 +47,13 @@ export const postVideoAnalyze = (
     .post(
       `${API}/cv/analyze/video?fps_fallback=${q.fps_fallback}&ref_len_m=${q.ref_len_m}&ref_len_px=${q.ref_len_px}&smoothing_window=${q.smoothing_window || 3}&persist=${!!q.persist}`,
       form,
-      { headers: { "Content-Type": "multipart/form-data" } }
+      { headers: headers({ "Content-Type": "multipart/form-data" }) }
     )
     .then((r) => r.data);
 
-export const listRuns = () => axios.get(`${API}/runs`).then((r) => r.data);
-export const getRun = (id: string) => axios.get(`${API}/runs/${id}`).then((r) => r.data);
-export const deleteRun = (id: string) => axios.delete(`${API}/runs/${id}`).then((r) => r.data);
+export const listRuns = () =>
+  axios.get(`${API}/runs`, { headers: headers() }).then((r) => r.data);
+export const getRun = (id: string) =>
+  axios.get(`${API}/runs/${id}`, { headers: headers() }).then((r) => r.data);
+export const deleteRun = (id: string) =>
+  axios.delete(`${API}/runs/${id}`, { headers: headers() }).then((r) => r.data);


### PR DESCRIPTION
## Summary
- add automatic x-api-key propagation for web axios requests using VITE_API_KEY
- document how to configure VITE_API_BASE and VITE_API_KEY for development

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cdd056b0b88326aadcd2584f7e6a91