### PR TITLE
feat: spin placeholders, feature flags, and optional impact-frame capture (+tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,11 @@ The UI currently calls the following endpoints: `/cv/mock/analyze`, `/cv/analyze
 * Set `REQUIRE_API_KEY=1` to require the header `x-api-key` to match `API_KEY` for analysis and runs endpoints.
 * Uploads are bounded by defaults: ZIPs ≤ 50 MB, ≤ 400 files, compression ratio ≤ 200×, and videos ≤ 80 MB. Override with `MAX_ZIP_SIZE_BYTES`, `MAX_ZIP_FILES`, `MAX_ZIP_RATIO`, or `MAX_VIDEO_BYTES`.
 
+### Feature flags
+
+- `ENABLE_SPIN` (default 0) – exponerar spin-placeholders i API (värden är `null` tills en spin-modul finns).
+- `CAPTURE_IMPACT_FRAMES` (default 1) – sparar ett litet `impact_preview.zip` kring första impact när `persist=true`. Tunas med `IMPACT_CAPTURE_BEFORE/AFTER`.
+
 ## Web UI
 
 The project ships with a Vite + React single-page app for uploading captures, kicking off mock runs, and browsing persisted runs.

--- a/cv_engine/calibration/simple.py
+++ b/cv_engine/calibration/simple.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
-from typing import Iterable, Tuple
+from typing import Any, Dict, Iterable, Tuple
 
 from cv_engine.metrics.kinematics import CalibrationParams, velocity_avg
 
@@ -46,12 +46,20 @@ def measure_from_tracks(ball, club, calib: CalibrationParams) -> KinematicMetric
     )
 
 
-def as_dict(m: KinematicMetrics) -> dict:
-    return {
-        "ball_speed_mps": m.ball_speed_mps,
-        "ball_speed_mph": m.ball_speed_mph,
-        "club_speed_mps": m.club_speed_mps,
-        "club_speed_mph": m.club_speed_mph,
-        "launch_deg": m.launch_deg,
-        "carry_m": m.carry_m,
+def as_dict(
+    m: KinematicMetrics, *, include_spin_placeholders: bool = True
+) -> Dict[str, Any]:
+    out: Dict[str, Any] = {
+        "ball_speed_mps": round(m.ball_speed_mps, 2),
+        "ball_speed_mph": round(m.ball_speed_mph, 1),
+        "club_speed_mps": round(m.club_speed_mps, 2),
+        "club_speed_mph": round(m.club_speed_mph, 1),
+        "launch_deg": round(m.launch_deg, 1),
+        "carry_m": round(m.carry_m, 1),
+        "metrics_version": 1,
     }
+    if include_spin_placeholders:
+        out.setdefault("spin_rpm", None)
+        out.setdefault("spin_axis_deg", None)
+        out.setdefault("club_path_deg", None)
+    return out

--- a/cv_engine/pipeline/analyze.py
+++ b/cv_engine/pipeline/analyze.py
@@ -70,13 +70,18 @@ def analyze_frames(
             "ball_speed_mps": 0.0,
             "ball_speed_mph": 0.0,
             "club_speed_mps": 0.0,
+            "club_speed_mph": 0.0,
             "launch_deg": 0.0,
             "carry_m": 0.0,
+            "metrics_version": 1,
+            "spin_rpm": None,
+            "spin_axis_deg": None,
+            "club_path_deg": None,
             "confidence": confidence,
         }
         return {"events": events, "metrics": metrics}
 
     m = measure_from_tracks(ball_track, club_track, calib)
-    metrics = as_dict(m)
+    metrics = as_dict(m, include_spin_placeholders=True)
     metrics["confidence"] = confidence
     return {"events": events, "metrics": metrics}

--- a/server/config.py
+++ b/server/config.py
@@ -5,6 +5,13 @@ from __future__ import annotations
 import os
 
 
+def env_bool(name: str, default: bool = False) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
 def _int_env(name: str, default: int) -> int:
     value = os.getenv(name)
     if value is None:
@@ -29,3 +36,8 @@ MAX_ZIP_SIZE_BYTES: int = _int_env("MAX_ZIP_SIZE_BYTES", 50_000_000)
 MAX_ZIP_FILES: int = _int_env("MAX_ZIP_FILES", 400)
 MAX_ZIP_RATIO: float = _float_env("MAX_ZIP_RATIO", 200.0)
 MAX_VIDEO_BYTES: int = _int_env("MAX_VIDEO_BYTES", 80_000_000)
+
+ENABLE_SPIN: bool = env_bool("ENABLE_SPIN", False)
+CAPTURE_IMPACT_FRAMES: bool = env_bool("CAPTURE_IMPACT_FRAMES", True)
+IMPACT_CAPTURE_BEFORE: int = _int_env("IMPACT_CAPTURE_BEFORE", 2)
+IMPACT_CAPTURE_AFTER: int = _int_env("IMPACT_CAPTURE_AFTER", 6)

--- a/server/routes/cv_analyze.py
+++ b/server/routes/cv_analyze.py
@@ -10,9 +10,16 @@ from pydantic import BaseModel, Field
 from cv_engine.io.framesource import frames_from_zip_bytes
 from cv_engine.metrics.kinematics import CalibrationParams
 from cv_engine.pipeline.analyze import analyze_frames
-from server.config import MAX_ZIP_FILES, MAX_ZIP_RATIO, MAX_ZIP_SIZE_BYTES
+from server.config import (
+    CAPTURE_IMPACT_FRAMES,
+    IMPACT_CAPTURE_AFTER,
+    IMPACT_CAPTURE_BEFORE,
+    MAX_ZIP_FILES,
+    MAX_ZIP_RATIO,
+    MAX_ZIP_SIZE_BYTES,
+)
 from server.security import require_api_key
-from server.storage.runs import save_run
+from server.storage.runs import save_impact_frames, save_run
 
 router = APIRouter(prefix="/cv", tags=["cv"], dependencies=[Depends(require_api_key)])
 
@@ -109,6 +116,22 @@ async def analyze(
             metrics=dict(metrics),
             events=list(events),
         )
+        impact_idx = events[0] if events else None
+        if rec and CAPTURE_IMPACT_FRAMES and impact_idx is not None:
+            start = max(0, impact_idx - IMPACT_CAPTURE_BEFORE)
+            stop = min(len(frames), impact_idx + IMPACT_CAPTURE_AFTER)
+            if stop > start:
+                preview = save_impact_frames(rec.run_id, frames[start:stop])
+                import json
+                from pathlib import Path
+
+                run_json_path = Path(preview).parent / "run.json"
+                try:
+                    data = json.loads(run_json_path.read_text())
+                    data["impact_preview"] = preview
+                    run_json_path.write_text(json.dumps(data, indent=2))
+                except Exception:
+                    pass
     return AnalyzeResponse(
         events=events, metrics=metrics, run_id=rec.run_id if rec else None
     )

--- a/server/routes/cv_analyze_video.py
+++ b/server/routes/cv_analyze_video.py
@@ -8,9 +8,14 @@ from pydantic import BaseModel, Field
 from cv_engine.io.videoreader import fps_from_video, frames_from_video
 from cv_engine.metrics.kinematics import CalibrationParams
 from cv_engine.pipeline.analyze import analyze_frames
-from server.config import MAX_VIDEO_BYTES
+from server.config import (
+    CAPTURE_IMPACT_FRAMES,
+    IMPACT_CAPTURE_AFTER,
+    IMPACT_CAPTURE_BEFORE,
+    MAX_VIDEO_BYTES,
+)
 from server.security import require_api_key
-from server.storage.runs import save_run
+from server.storage.runs import save_impact_frames, save_run
 
 router = APIRouter(
     prefix="/cv", tags=["cv-video"], dependencies=[Depends(require_api_key)]
@@ -108,6 +113,22 @@ async def analyze_video(
             metrics=dict(metrics),
             events=list(events),
         )
+        impact_idx = events[0] if events else None
+        if rec and CAPTURE_IMPACT_FRAMES and impact_idx is not None:
+            start = max(0, impact_idx - IMPACT_CAPTURE_BEFORE)
+            stop = min(len(frames), impact_idx + IMPACT_CAPTURE_AFTER)
+            if stop > start:
+                preview = save_impact_frames(rec.run_id, frames[start:stop])
+                import json
+                from pathlib import Path
+
+                run_json_path = Path(preview).parent / "run.json"
+                try:
+                    data = json.loads(run_json_path.read_text())
+                    data["impact_preview"] = preview
+                    run_json_path.write_text(json.dumps(data, indent=2))
+                except Exception:
+                    pass
     return AnalyzeResponse(
         events=events, metrics=metrics, run_id=rec.run_id if rec else None
     )

--- a/server/routes/runs.py
+++ b/server/routes/runs.py
@@ -52,6 +52,7 @@ def get_run(run_id: str):
         "params": r.params,
         "metrics": r.metrics,
         "events": r.events,
+        "impact_preview": r.impact_preview,
     }
 
 

--- a/server/tests/test_config_env.py
+++ b/server/tests/test_config_env.py
@@ -27,6 +27,13 @@ def test_env_parsing_accepts_valid_values(monkeypatch):
     assert config.MAX_ZIP_FILES == 42
 
 
+def test_env_bool_truthy_values(monkeypatch):
+    monkeypatch.setenv("ENABLE_SPIN", "YeS")
+    sys.modules.pop("server.config", None)
+    config = importlib.import_module("server.config")
+    assert config.ENABLE_SPIN is True
+
+
 def teardown_module(module):  # noqa: D401 - test cleanup helper
     """Reset server.config module state between tests."""
 

--- a/server/tests/test_impact_capture.py
+++ b/server/tests/test_impact_capture.py
@@ -1,0 +1,42 @@
+import json
+import os
+import zipfile
+
+from fastapi.testclient import TestClient
+
+from server.app import app
+from server.routes import cv_mock
+from server.storage import runs as runs_storage
+
+
+def test_impact_preview_zip_saved(tmp_path, monkeypatch):
+    runs_dir = (tmp_path / "runs").resolve()
+    monkeypatch.setattr(runs_storage, "RUNS_DIR", runs_dir)
+    monkeypatch.setenv("GOLFIQ_RUNS_DIR", str(runs_dir))
+    monkeypatch.setenv("CAPTURE_IMPACT_FRAMES", "1")
+
+    class FakeEvent:
+        frame_index = 3
+
+    class FakeImpactDetector:
+        def __init__(self, *args, **kwargs):  # pragma: no cover - simple stub
+            pass
+
+        def run(self, frames):
+            return [FakeEvent()]
+
+    monkeypatch.setattr(cv_mock, "ImpactDetector", FakeImpactDetector)
+    with TestClient(app) as client:
+        response = client.post(
+            "/cv/mock/analyze",
+            json={"frames": 8, "fps": 120.0, "persist": True},
+        )
+    assert response.status_code == 200
+    run_id = response.json().get("run_id")
+    assert run_id
+    run_json_path = runs_dir / run_id / "run.json"
+    data = json.loads(run_json_path.read_text())
+    preview_path = data.get("impact_preview")
+    assert preview_path and os.path.exists(preview_path)
+    with zipfile.ZipFile(preview_path, "r") as zf:
+        assert any(name.endswith(".npy") for name in zf.namelist())

--- a/server/tests/test_spin_placeholders.py
+++ b/server/tests/test_spin_placeholders.py
@@ -1,0 +1,15 @@
+from fastapi.testclient import TestClient
+
+from server.app import app
+
+
+def test_mock_analyze_contains_spin_placeholders(monkeypatch):
+    monkeypatch.setenv("ENABLE_SPIN", "0")
+    with TestClient(app) as client:
+        response = client.post("/cv/mock/analyze", json={"frames": 6, "fps": 120.0})
+    assert response.status_code == 200
+    metrics = response.json()["metrics"]
+    assert "metrics_version" in metrics
+    assert metrics.get("spin_rpm") is None
+    assert metrics.get("spin_axis_deg") is None
+    assert metrics.get("club_path_deg") is None

--- a/server/tests/test_storage_runs.py
+++ b/server/tests/test_storage_runs.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Tuple
+
+from server.storage import runs as runs_storage
+
+
+def _setup_runs_dir(tmp_path, monkeypatch) -> Tuple[str, str]:
+    runs_dir = (tmp_path / "runs").resolve()
+    monkeypatch.setattr(runs_storage, "RUNS_DIR", runs_dir)
+    monkeypatch.setenv("GOLFIQ_RUNS_DIR", str(runs_dir))
+    return str(runs_dir), "1234567890-deadbeef"
+
+
+def test_save_and_load_round_trip(tmp_path, monkeypatch):
+    _setup_runs_dir(tmp_path, monkeypatch)
+
+    record = runs_storage.save_run(
+        source="unit-test",
+        mode="mock",
+        params={"frames": 4},
+        metrics={"ball_speed_mps": 1.0},
+        events=[1, 2],
+    )
+
+    loaded = runs_storage.load_run(record.run_id)
+
+    assert loaded is not None
+    assert loaded.run_id == record.run_id
+    assert loaded.events == [1, 2]
+
+    run_ids = [r.run_id for r in runs_storage.list_runs()]
+    assert record.run_id in run_ids
+
+
+def test_delete_run_missing_directory(tmp_path, monkeypatch):
+    _, run_id = _setup_runs_dir(tmp_path, monkeypatch)
+
+    assert runs_storage.delete_run(run_id) is False
+
+
+def test_list_runs_without_directory(tmp_path, monkeypatch):
+    _setup_runs_dir(tmp_path, monkeypatch)
+
+    assert runs_storage.list_runs() == []

--- a/web/src/pages/Analyze.tsx
+++ b/web/src/pages/Analyze.tsx
@@ -7,9 +7,14 @@ interface AnalyzeMetrics {
   ball_speed_mps?: number;
   ball_speed_mph?: number;
   club_speed_mps?: number;
+  club_speed_mph?: number;
   launch_deg?: number;
   carry_m?: number;
   confidence?: number;
+  metrics_version?: number;
+  spin_rpm?: number | null;
+  spin_axis_deg?: number | null;
+  club_path_deg?: number | null;
   [key: string]: unknown;
 }
 
@@ -71,7 +76,7 @@ export default function AnalyzePage() {
   const { inputRef: zipRef, reset: resetZip } = useFileInput();
   const { inputRef: videoRef, reset: resetVideo } = useFileInput();
 
-  const metrics = useMemo(() => result?.metrics ?? {}, [result]);
+  const metrics = useMemo<AnalyzeMetrics>(() => result?.metrics ?? {}, [result]);
 
   const [zipForm, setZipForm] = useState({
     file: null as File | null,
@@ -172,6 +177,15 @@ export default function AnalyzePage() {
           secondary={metric.secondary?.(metrics)}
         />
       ))}
+      {metrics?.spin_rpm != null && (
+        <MetricCard title="Spin (rpm)" value={metrics.spin_rpm} />
+      )}
+      {metrics?.spin_axis_deg != null && (
+        <MetricCard title="Spin Axis (°)" value={metrics.spin_axis_deg} />
+      )}
+      {metrics?.club_path_deg != null && (
+        <MetricCard title="Club Path (°)" value={metrics.club_path_deg} />
+      )}
     </div>
   );
 

--- a/web/src/pages/MockAnalyze.tsx
+++ b/web/src/pages/MockAnalyze.tsx
@@ -15,9 +15,11 @@ interface MockFormState {
   club_dy_px: number;
 }
 
+type MockMetrics = Record<string, number | null | undefined>;
+
 interface MockResult {
   run_id?: string;
-  metrics?: Record<string, number>;
+  metrics?: MockMetrics;
   events?: Array<Record<string, unknown>>;
 }
 
@@ -65,7 +67,7 @@ export default function MockAnalyzePage() {
     }
   };
 
-  const metrics = result?.metrics ?? {};
+  const metrics: MockMetrics = result?.metrics ?? {};
 
   return (
     <section className="space-y-6">
@@ -220,9 +222,26 @@ export default function MockAnalyzePage() {
               </p>
             )}
             <div className="mt-6 grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-              {Object.entries(metrics).map(([key, value]) => (
-                <MetricCard key={key} title={key} value={value} />
-              ))}
+              {Object.entries(metrics)
+                .filter(
+                  ([key]) =>
+                    key !== "spin_rpm" &&
+                    key !== "spin_axis_deg" &&
+                    key !== "club_path_deg" &&
+                    key !== "metrics_version"
+                )
+                .map(([key, value]) => (
+                  <MetricCard key={key} title={key} value={value} />
+                ))}
+              {metrics?.spin_rpm != null && (
+                <MetricCard title="Spin (rpm)" value={metrics.spin_rpm} />
+              )}
+              {metrics?.spin_axis_deg != null && (
+                <MetricCard title="Spin Axis (°)" value={metrics.spin_axis_deg} />
+              )}
+              {metrics?.club_path_deg != null && (
+                <MetricCard title="Club Path (°)" value={metrics.club_path_deg} />
+              )}
             </div>
           </div>
           {result.events && result.events.length > 0 && (

--- a/web/src/pages/RunDetail.tsx
+++ b/web/src/pages/RunDetail.tsx
@@ -4,6 +4,7 @@ import { getRun } from "../api";
 
 interface RunDetailData {
   run_id?: string;
+  impact_preview?: string | null;
   [key: string]: unknown;
 }
 
@@ -71,6 +72,21 @@ export default function RunDetailPage() {
       {error && (
         <div className="rounded-md border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-200">
           {error}
+        </div>
+      )}
+
+      {!loading && data?.impact_preview && (
+        <div className="rounded-md border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-xs text-emerald-100">
+          Impact preview saved as{" "}
+          <a
+            href={String(data.impact_preview)}
+            target="_blank"
+            rel="noreferrer"
+            className="font-semibold text-emerald-200 underline decoration-dotted"
+          >
+            impact_preview.zip
+          </a>
+          .
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- add environment-backed feature flags and extend kinematic metrics with `metrics_version` plus spin placeholders
- persist optional impact previews for saved runs and expose the path in run details and the UI
- conditionally render spin metrics in the web app and document the new feature flags alongside regression tests for spin placeholders and impact capture

## Testing
- black . && isort . && flake8 . && pytest -q


------
https://chatgpt.com/codex/tasks/task_e_68ce5ee375248326bed1f7afe59cd9d2