### PR TITLE
chore(release): set BUILD_VERSION & GIT_SHA for /health (release.yml + Dockerfile)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,8 @@ jobs:
           build-args: |
             PY_IMAGE=python:3.11-slim
             VIDEO_EXTRAS=1
+            BUILD_VERSION=${{ env.BUILD_VERSION }}
+            GIT_SHA=${{ env.GIT_SHA }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,6 @@ RUN npm run build
 ARG PY_IMAGE=python:3.11-slim
 FROM ${PY_IMAGE} AS runtime
 
-ARG BUILD_VERSION=dev
-ARG GIT_SHA=unknown
-
 # System libs for opencv/ffmpeg (video extras)
 RUN apt-get update && apt-get install -y --no-install-recommends \
       libgl1 libglib2.0-0 ffmpeg ca-certificates && \
@@ -46,9 +43,13 @@ RUN if [ "$VIDEO_EXTRAS" = "1" ]; then pip install -e ".[video]"; fi
 RUN useradd -m appuser && chown -R appuser:appuser /app
 USER appuser
 
-ENV BUILD_VERSION=${BUILD_VERSION} GIT_SHA=${GIT_SHA}
 ENV SERVE_WEB=1 PORT=8000 HOST=0.0.0.0 GOLFIQ_MOCK=1 GOLFIQ_RUNS_DIR=/data/runs
 EXPOSE 8000
 VOLUME ["/data/runs"]
+
+# Build info for /health endpoint
+ARG BUILD_VERSION=dev
+ARG GIT_SHA=unknown
+ENV BUILD_VERSION=${BUILD_VERSION} GIT_SHA=${GIT_SHA}
 
 CMD ["uvicorn", "server.app:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- forward the release workflow tag and sha as Docker build args
- bake BUILD_VERSION and GIT_SHA into the runtime image for the /health endpoint

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce9e2e14c48326b4236d5742f3fdd8