### PR TITLE
ci: expand accuracy harness (high/low launch goldens, smoothing & edge cases)

### DIFF
--- a/cv_engine/tests/test_accuracy_golden_v2.py
+++ b/cv_engine/tests/test_accuracy_golden_v2.py
@@ -1,0 +1,54 @@
+import math
+
+from cv_engine.calibration.simple import measure_from_tracks
+from cv_engine.metrics.kinematics import CalibrationParams
+
+
+def _ballistic_tracks(v0_mps, launch_deg, fps, m_per_px, n=40):
+    dt = 1.0 / fps
+    g = 9.81
+    th = math.radians(launch_deg)
+    vx, vy = v0_mps * math.cos(th), v0_mps * math.sin(th)
+    pts_px = []
+    for i in range(n):
+        t = i * dt
+        x = vx * t
+        y = vy * t - 0.5 * g * t * t
+        if y < 0 and i > 1:
+            break
+        pts_px.append((x / m_per_px, 100 - y / m_per_px))
+    return pts_px
+
+
+def _expected_carry_no_drag(v0, launch_deg):
+    return (v0 * v0 * math.sin(math.radians(2 * launch_deg))) / 9.81
+
+
+def test_golden_high_launch_mid_speed():
+    fps = 240.0
+    mpp = 1 / 120
+    calib = CalibrationParams.from_reference(1.0, 120.0, fps)
+    v0 = 55.0
+    launch = 20.0
+    ball = _ballistic_tracks(v0, launch, fps, mpp, n=60)
+    club = [(i * 1.5, 110) for i in range(len(ball))]
+    m = measure_from_tracks(ball, club, calib)
+    assert abs(m.ball_speed_mps - v0) <= 1.0
+    assert abs(m.launch_deg - launch) <= 1.2
+    exp = _expected_carry_no_drag(v0, launch)
+    assert abs(m.carry_m - exp) <= 6.0
+
+
+def test_golden_low_launch_high_speed_short_track():
+    fps = 120.0
+    mpp = 1 / 100
+    calib = CalibrationParams.from_reference(1.0, 100.0, fps)
+    v0 = 60.0
+    launch = 5.0
+    ball = _ballistic_tracks(v0, launch, fps, mpp, n=10)
+    club = [(i * 1.5, 110) for i in range(len(ball))]
+    m = measure_from_tracks(ball, club, calib)
+    assert abs(m.ball_speed_mps - v0) <= 1.5
+    assert abs(m.launch_deg - launch) <= 1.5
+    exp = _expected_carry_no_drag(v0, launch)
+    assert abs(m.carry_m - exp) <= 8.0

--- a/cv_engine/tests/test_smoothing_variation.py
+++ b/cv_engine/tests/test_smoothing_variation.py
@@ -1,0 +1,35 @@
+import statistics as st
+
+from cv_engine.calibration.simple import measure_from_tracks
+from cv_engine.metrics.kinematics import CalibrationParams
+
+
+def _angle_series(track):
+    import math
+
+    ang = []
+    for (x0, y0), (x1, y1) in zip(track, track[1:]):
+        dx, dy = (x1 - x0), (y1 - y0)
+        ang.append(math.degrees(math.atan2(-(dy), dx if dx != 0 else 1e-9)))
+    return ang
+
+
+def test_smoothing_reduces_angle_variation():
+    calib = CalibrationParams.from_reference(1.0, 100.0, 120.0)
+    base = [(i * 2.0, 100 - i * 1.0) for i in range(25)]
+    jitter = [
+        (x + (1 if i % 3 == 0 else 0), y + (1 if i % 4 == 0 else 0))
+        for i, (x, y) in enumerate(base)
+    ]
+    club = [(i * 1.5, 110) for i in range(len(jitter))]
+    m1 = measure_from_tracks(jitter, club, calib)
+    a1 = _angle_series(jitter)
+
+    from cv_engine.metrics.smoothing import moving_average
+
+    smooth = moving_average(jitter, window=5)
+    a2 = _angle_series(smooth)
+    assert st.pstdev(a2) <= st.pstdev(a1) * 0.85
+
+    m0 = measure_from_tracks(base, club, calib)
+    assert abs(m1.launch_deg - m0.launch_deg) <= 2.5

--- a/server/tests/test_metrics_edge_short_track.py
+++ b/server/tests/test_metrics_edge_short_track.py
@@ -1,0 +1,28 @@
+from fastapi.testclient import TestClient
+
+from server.app import app
+
+
+def test_short_track_returns_zero_and_placeholders():
+    with TestClient(app) as client:
+        payload = {
+            "frames": 2,
+            "fps": 120,
+            "ball_dx_px": 0.001,
+            "ball_dy_px": 0.0340625,
+            "club_dx_px": 0.0,
+            "club_dy_px": 0.0,
+        }
+        r = client.post("/cv/mock/analyze", json=payload)
+        assert r.status_code == 200, r.text
+        m = r.json()["metrics"]
+        for k in [
+            "ball_speed_mps",
+            "ball_speed_mph",
+            "club_speed_mps",
+            "launch_deg",
+            "carry_m",
+        ]:
+            assert m[k] == 0 or m[k] == 0.0
+        assert "metrics_version" in m
+        assert "spin_rpm" in m and m["spin_rpm"] is None


### PR DESCRIPTION
## Summary
- add ballistic golden tests covering higher launch and low launch/high speed scenarios
- measure that jitter smoothing reduces angle variance while keeping launch near baseline
- ensure the mock CV API returns zeroed metrics and placeholders for minimal track input

## Testing
- black .
- isort .
- flake8 .
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ceb055d3ac8326a00cdd8078ab16de