### PR TITLE
feat(ar-hud-mobile): android/ios stubs + shared telemetry schema (CI-safe)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,14 @@ name: ci
 
 on:
   pull_request:
+    paths-ignore:
+      - 'android/**'
+      - 'ios/**'
   push:
     branches: [main]
+    paths-ignore:
+      - 'android/**'
+      - 'ios/**'
 
 permissions:
   contents: write

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -2,8 +2,14 @@ name: static-analysis
 
 on:
   pull_request:
+    paths-ignore:
+      - 'android/**'
+      - 'ios/**'
   push:
     branches: [main]
+    paths-ignore:
+      - 'android/**'
+      - 'ios/**'
 
 jobs:
   mypy:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -1,8 +1,14 @@
 name: web
 on:
   pull_request:
+    paths-ignore:
+      - 'android/**'
+      - 'ios/**'
   push:
     branches: [main]
+    paths-ignore:
+      - 'android/**'
+      - 'ios/**'
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,9 @@ web/dist/
 !.codex/README.md
 artifacts/
 .nvmrc
+
+# Mobile build artifacts
+android/.gradle/
+android/local.properties
+ios/DerivedData/
+ios/build/

--- a/android/README.md
+++ b/android/README.md
@@ -1,0 +1,7 @@
+# Android AR-HUD Stub
+
+This module contains placeholder models and interfaces for the AR-HUD mobile client.
+
+> **Note**
+> The Android project is not built in CI. These files exist to document the data
+> structures shared with iOS and the backend.

--- a/android/app/src/main/java/com/golfiq/hud/model/ShotEvent.kt
+++ b/android/app/src/main/java/com/golfiq/hud/model/ShotEvent.kt
@@ -1,0 +1,7 @@
+package com.golfiq.hud.model
+
+data class ShotEvent(
+    val id: String,
+    val sessionId: String,
+    val telemetry: Telemetry
+)

--- a/android/app/src/main/java/com/golfiq/hud/model/Telemetry.kt
+++ b/android/app/src/main/java/com/golfiq/hud/model/Telemetry.kt
@@ -1,0 +1,11 @@
+package com.golfiq.hud.model
+
+data class Telemetry(
+    val timestampMs: Long,
+    val club: String?,
+    val ballSpeed: Double?,
+    val clubSpeed: Double?,
+    val launchAngle: Double?,
+    val spinRpm: Int?,
+    val carryMeters: Double?
+)

--- a/android/app/src/main/java/com/golfiq/hud/net/TelemetrySocketClient.kt
+++ b/android/app/src/main/java/com/golfiq/hud/net/TelemetrySocketClient.kt
@@ -1,0 +1,7 @@
+package com.golfiq.hud.net
+
+interface TelemetrySocketClient {
+    fun connect()
+    fun disconnect()
+    fun onMessage(json: String)
+}

--- a/docs/ar-hud-mobile-stubs.md
+++ b/docs/ar-hud-mobile-stubs.md
@@ -1,0 +1,22 @@
+# AR-HUD Mobile Stubs
+
+This repository contains lightweight stubs for the augmented reality heads-up
+display (AR-HUD) mobile clients. The goal is to keep platform code present for
+API reference without forcing CI to build Android or iOS artifacts.
+
+## Layout
+
+- `android/` — Kotlin data models and socket interface used by the Android app.
+- `ios/` — Swift data models mirroring the Android payloads.
+- `shared/telemetry/` — JSON schema and utilities that define the canonical
+  telemetry payload.
+
+## CI Strategy
+
+GitHub Actions workflows are configured to ignore changes limited to `android/**`
+and `ios/**`, ensuring server/web pipelines are unaffected by mobile-only edits.
+
+## Next Steps
+
+Future work will integrate real transport layers, live telemetry ingestion, and
+platform-specific build steps once backend endpoints are finalized.

--- a/ios/Models/ShotEvent.swift
+++ b/ios/Models/ShotEvent.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public struct ShotEvent: Codable {
+    public let id: String
+    public let sessionId: String
+    public let telemetry: Telemetry
+}

--- a/ios/Models/Telemetry.swift
+++ b/ios/Models/Telemetry.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public struct Telemetry: Codable {
+    public let timestampMs: Int64
+    public let club: String?
+    public let ballSpeed: Double?
+    public let clubSpeed: Double?
+    public let launchAngle: Double?
+    public let spinRpm: Int?
+    public let carryMeters: Double?
+}

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,0 +1,6 @@
+# iOS AR-HUD Stub
+
+Swift models for the AR-HUD app live here as documentation-only stubs.
+
+These files are intentionally lightweight and excluded from CI builds. They
+capture the shared telemetry contract consumed by Android and the backend.

--- a/shared/telemetry/README.md
+++ b/shared/telemetry/README.md
@@ -1,0 +1,11 @@
+# Shared Telemetry Schema
+
+This folder defines the cross-platform telemetry payload shared between the
+mobile clients and the backend.
+
+* `telemetry.schema.json` encodes the canonical payload contract.
+* Android maps to `com.golfiq.hud.model.Telemetry` and `ShotEvent`.
+* iOS maps to `Telemetry` and `ShotEvent` in `ios/Models`.
+
+> The schema intentionally allows nullable fields for optional club tracking
+> properties. Only the `timestampMs` field is required.

--- a/shared/telemetry/telemetry.schema.json
+++ b/shared/telemetry/telemetry.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Telemetry",
+  "type": "object",
+  "properties": {
+    "timestampMs": { "type": "integer" },
+    "club": { "type": ["string", "null"] },
+    "ballSpeed": { "type": ["number", "null"] },
+    "clubSpeed": { "type": ["number", "null"] },
+    "launchAngle": { "type": ["number", "null"] },
+    "spinRpm": { "type": ["integer", "null"] },
+    "carryMeters": { "type": ["number", "null"] }
+  },
+  "required": ["timestampMs"]
+}

--- a/shared/telemetry/validate.ts
+++ b/shared/telemetry/validate.ts
@@ -1,0 +1,11 @@
+/**
+ * Placeholder validation helper for the telemetry schema.
+ *
+ * This file is intentionally not wired into CI to avoid introducing
+ * Node.js dependencies. It documents how a consumer could load and
+ * validate telemetry payloads locally.
+ */
+export function validateTelemetry(_: unknown): boolean {
+  // Implement JSON schema validation in app-specific tooling.
+  return true;
+}


### PR DESCRIPTION
## Summary
- Adds compile-clean Android/iOS AR-HUD model stubs
- Introduces shared telemetry JSON schema
- Updates CI to ignore mobile paths to avoid breaking server tests

## Details
- Android: Telemetry.kt, ShotEvent.kt, TelemetrySocketClient.kt (interface only)
- iOS: Telemetry.swift, ShotEvent.swift
- Shared: telemetry.schema.json (+ README)
- CI: paths-ignore for `android/**` and `ios/**`

## Safety
- No server/build change except CI ignore rules
- Idempotent; re-running does not duplicate files
- No external deps added

## Next
- Hook live telemetry (WebSocket) once backend endpoint is finalized
- Add edge build steps (TFLite/CoreML/ONNX) in a separate PR

------
https://chatgpt.com/codex/tasks/task_e_68dacd2cabd08326b8bbf9c46d44c6cd