### PR TITLE
fix(cv): respect CV_MOCK override

### DIFF
--- a/docs/cv_mock_override.md
+++ b/docs/cv_mock_override.md
@@ -1,0 +1,63 @@
+# CV Mock Override Behavior
+
+The CV APIs default to the mock inference backend, but the default can now be
+configured per environment and overridden per request.
+
+## Default
+
+Set the `CV_MOCK` environment variable (defaults to `true`) to choose which
+backend is used when no request override is provided.
+
+```
+# .env
+CV_MOCK=true  # or false
+```
+
+## Override Precedence
+
+The backend used for a given request is determined in the following order:
+
+1. Query parameter `mock` (e.g. `/cv/analyze?mock=false`).
+2. Header `x-cv-mock: true|false`.
+3. Body field `mock` (JSON or multipart form field, depending on the endpoint).
+4. Environment default (`CV_MOCK`).
+
+The first value that is provided is used. All overrides accept common boolean
+strings such as `true`, `false`, `1`, or `0`.
+
+## Examples
+
+```http
+POST /cv/analyze?mock=false
+x-api-key: <key>
+
+--multipart boundary--
+Content-Disposition: form-data; name="frames_zip"; filename="frames.zip"
+Content-Type: application/zip
+```
+
+```http
+POST /cv/analyze/video
+x-api-key: <key>
+x-cv-mock: true
+
+--multipart boundary--
+Content-Disposition: form-data; name="video"; filename="swing.mp4"
+Content-Type: video/mp4
+```
+
+```http
+POST /cv/analyze
+Content-Type: multipart/form-data; boundary=boundary
+
+--boundary
+Content-Disposition: form-data; name="mock"
+
+true
+--boundary
+Content-Disposition: form-data; name="frames_zip"; filename="frames.zip"
+Content-Type: application/zip
+```
+
+Response headers now include `x-cv-source: mock|real` to indicate the backend
+used for the request.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 pythonpath = .
-testpaths = server/tests cv_engine/tests
+testpaths = tests server/tests cv_engine/tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 fastapi
-pydantic-settings
 numpy>=1.26
 python-dotenv
 python-multipart

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 fastapi
+pydantic-settings
 numpy>=1.26
 python-dotenv
 python-multipart

--- a/server/config.py
+++ b/server/config.py
@@ -3,36 +3,21 @@
 from __future__ import annotations
 
 import os
+from dataclasses import dataclass
 from functools import lru_cache
 from typing import Any
 
-try:  # Pydantic v2
-    from pydantic_settings import BaseSettings, SettingsConfigDict  # type: ignore
-except ImportError:  # pragma: no cover - fallback for pydantic v1
-    from pydantic import BaseSettings  # type: ignore
 
-    SettingsConfigDict = None  # type: ignore
-
-from pydantic import Field
-
-
-class _Settings(BaseSettings):
-    cv_mock: bool = Field(default=True, alias="CV_MOCK")
-
-    if SettingsConfigDict is not None:  # pragma: no branch
-        model_config = SettingsConfigDict(env_file=".env", extra="ignore")
-    else:  # pragma: no cover - executed on pydantic v1
-
-        class Config:
-            env_file = ".env"
-            case_sensitive = False
+@dataclass(frozen=True)
+class _Settings:
+    cv_mock: bool = True
 
 
 @lru_cache(maxsize=1)
 def get_settings() -> _Settings:
     """Return cached application settings."""
 
-    return _Settings()  # type: ignore[call-arg]
+    return _Settings(cv_mock=env_bool("CV_MOCK", True))
 
 
 def reset_settings_cache() -> None:

--- a/server/config.py
+++ b/server/config.py
@@ -22,6 +22,7 @@ class _Settings(BaseSettings):
     if SettingsConfigDict is not None:  # pragma: no branch
         model_config = SettingsConfigDict(env_file=".env", extra="ignore")
     else:  # pragma: no cover - executed on pydantic v1
+
         class Config:
             env_file = ".env"
             case_sensitive = False
@@ -45,6 +46,12 @@ def env_bool(name: str, default: bool = False) -> bool:
     if value is None:
         return default
     return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def yolo_inference_enabled() -> bool:
+    """Return True when runtime YOLO inference should be used."""
+
+    return env_bool("YOLO_INFERENCE", False)
 
 
 def _int_env(name: str, default: int) -> int:

--- a/server/config.py
+++ b/server/config.py
@@ -3,6 +3,41 @@
 from __future__ import annotations
 
 import os
+from functools import lru_cache
+from typing import Any
+
+try:  # Pydantic v2
+    from pydantic_settings import BaseSettings, SettingsConfigDict  # type: ignore
+except ImportError:  # pragma: no cover - fallback for pydantic v1
+    from pydantic import BaseSettings  # type: ignore
+
+    SettingsConfigDict = None  # type: ignore
+
+from pydantic import Field
+
+
+class _Settings(BaseSettings):
+    cv_mock: bool = Field(default=True, alias="CV_MOCK")
+
+    if SettingsConfigDict is not None:  # pragma: no branch
+        model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+    else:  # pragma: no cover - executed on pydantic v1
+        class Config:
+            env_file = ".env"
+            case_sensitive = False
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> _Settings:
+    """Return cached application settings."""
+
+    return _Settings()  # type: ignore[call-arg]
+
+
+def reset_settings_cache() -> None:
+    """Clear cached settings (primarily for tests)."""
+
+    get_settings.cache_clear()
 
 
 def env_bool(name: str, default: bool = False) -> bool:
@@ -41,3 +76,24 @@ ENABLE_SPIN: bool = env_bool("ENABLE_SPIN", False)
 CAPTURE_IMPACT_FRAMES: bool = env_bool("CAPTURE_IMPACT_FRAMES", True)
 IMPACT_CAPTURE_BEFORE: int = _int_env("IMPACT_CAPTURE_BEFORE", 2)
 IMPACT_CAPTURE_AFTER: int = _int_env("IMPACT_CAPTURE_AFTER", 6)
+
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+_FALSE_VALUES = {"0", "false", "no", "off"}
+
+
+def coerce_boolish(value: Any) -> bool | None:
+    """Attempt to coerce *value* into a boolean."""
+
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in _TRUE_VALUES:
+            return True
+        if lowered in _FALSE_VALUES:
+            return False
+    return None

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,4 +1,5 @@
-﻿fastapi
+fastapi
+pydantic-settings
 pyyaml
 httpx
 numpy>=1.26

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,5 +1,4 @@
 fastapi
-pydantic-settings
 pyyaml
 httpx
 numpy>=1.26

--- a/server/routes/cv_analyze_video.py
+++ b/server/routes/cv_analyze_video.py
@@ -50,10 +50,14 @@ class AnalyzeResponse(BaseModel):
     events: list[int]
     metrics: dict
     run_id: str | None = None
+
+
 @router.post("/analyze/video", response_model=AnalyzeResponse)
 async def analyze_video(
     response: Response,
-    mock: bool | None = Query(None, description="Optional override for CV mock backend"),
+    mock: bool | None = Query(
+        None, description="Optional override for CV mock backend"
+    ),
     mock_header: str | None = Header(default=None, alias="x-cv-mock"),
     mock_form: bool | None = Form(
         default=None,

--- a/server/services/cv_mock.py
+++ b/server/services/cv_mock.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from server.config import coerce_boolish, get_settings
+from server.config import coerce_boolish, get_settings, yolo_inference_enabled
 
 
 def effective_mock(*candidates: Any) -> bool:
@@ -19,4 +19,6 @@ def effective_mock(*candidates: Any) -> bool:
         coerced = coerce_boolish(candidate)
         if coerced is not None:
             return coerced
+    if yolo_inference_enabled():
+        return False
     return get_settings().cv_mock

--- a/server/services/cv_mock.py
+++ b/server/services/cv_mock.py
@@ -1,0 +1,22 @@
+"""Utilities for selecting CV mock vs. real backends."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from server.config import coerce_boolish, get_settings
+
+
+def effective_mock(*candidates: Any) -> bool:
+    """Return the effective mock flag using the provided candidates.
+
+    Values are evaluated in order and the first non-``None`` candidate wins.
+    If all candidates are ``None``, the environment default (``CV_MOCK``) is
+    used instead.
+    """
+
+    for candidate in candidates:
+        coerced = coerce_boolish(candidate)
+        if coerced is not None:
+            return coerced
+    return get_settings().cv_mock

--- a/tests/test_cv_mock_override.py
+++ b/tests/test_cv_mock_override.py
@@ -37,9 +37,7 @@ def _patch_cv(monkeypatch: pytest.MonkeyPatch) -> list[bool]:
     monkeypatch.setattr(
         "server.routes.cv_analyze.frames_from_zip_bytes", fake_frames_from_zip
     )
-    monkeypatch.setattr(
-        "server.routes.cv_analyze.analyze_frames", fake_analyze_frames
-    )
+    monkeypatch.setattr("server.routes.cv_analyze.analyze_frames", fake_analyze_frames)
     return calls
 
 
@@ -132,6 +130,21 @@ def test_cv_analyze_body_override_when_env_false(
     calls = _patch_cv(monkeypatch)
 
     response = _post_analyze(client, data={"mock": "true"})
+
+    assert response.status_code == 200
+    assert calls == [True]
+    assert response.headers["x-cv-source"] == "mock"
+
+
+def test_cv_analyze_query_override_beats_yolo_flag(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CV_MOCK", "true")
+    monkeypatch.setenv("YOLO_INFERENCE", "true")
+    reset_settings_cache()
+    calls = _patch_cv(monkeypatch)
+
+    response = _post_analyze(client, query={"mock": "true"})
 
     assert response.status_code == 200
     assert calls == [True]

--- a/tests/test_cv_mock_override.py
+++ b/tests/test_cv_mock_override.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import io
+import zipfile
+
+import pytest
+from fastapi.testclient import TestClient
+
+from server.app import app
+from server.config import reset_settings_cache
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def _make_zip_bytes() -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as zf:
+        zf.writestr("frame0.npy", b"0")
+        zf.writestr("frame1.npy", b"1")
+    return buffer.getvalue()
+
+
+def _patch_cv(monkeypatch: pytest.MonkeyPatch) -> list[bool]:
+    calls: list[bool] = []
+
+    def fake_frames_from_zip(_: bytes) -> list[object]:
+        return [object(), object()]
+
+    def fake_analyze_frames(*_: object, mock: bool, **__: object) -> dict:
+        calls.append(mock)
+        return {"events": [], "metrics": {"confidence": 0.0}}
+
+    monkeypatch.setattr(
+        "server.routes.cv_analyze.frames_from_zip_bytes", fake_frames_from_zip
+    )
+    monkeypatch.setattr(
+        "server.routes.cv_analyze.analyze_frames", fake_analyze_frames
+    )
+    return calls
+
+
+def _post_analyze(
+    client: TestClient,
+    *,
+    query: dict[str, str] | None = None,
+    headers: dict[str, str] | None = None,
+    data: dict[str, str] | None = None,
+) -> object:
+    files = {"frames_zip": ("frames.zip", _make_zip_bytes(), "application/zip")}
+    return client.post(
+        "/cv/analyze",
+        params=query or {},
+        headers=headers or {},
+        data=data or {},
+        files=files,
+    )
+
+
+def test_cv_analyze_env_default_true_uses_mock(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CV_MOCK", "true")
+    reset_settings_cache()
+    calls = _patch_cv(monkeypatch)
+
+    response = _post_analyze(client)
+
+    assert response.status_code == 200
+    assert calls == [True]
+    assert response.headers["x-cv-source"] == "mock"
+
+
+def test_cv_analyze_env_default_false_uses_real(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CV_MOCK", "false")
+    reset_settings_cache()
+    calls = _patch_cv(monkeypatch)
+
+    response = _post_analyze(client)
+
+    assert response.status_code == 200
+    assert calls == [False]
+    assert response.headers["x-cv-source"] == "real"
+
+
+def test_cv_analyze_query_override_beats_header_and_env(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CV_MOCK", "true")
+    reset_settings_cache()
+    calls = _patch_cv(monkeypatch)
+
+    response = _post_analyze(
+        client,
+        query={"mock": "false"},
+        headers={"x-cv-mock": "true"},
+    )
+
+    assert response.status_code == 200
+    assert calls == [False]
+    assert response.headers["x-cv-source"] == "real"
+
+
+def test_cv_analyze_header_override_beats_body_and_env(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CV_MOCK", "false")
+    reset_settings_cache()
+    calls = _patch_cv(monkeypatch)
+
+    response = _post_analyze(
+        client,
+        headers={"x-cv-mock": "true"},
+        data={"mock": "false"},
+    )
+
+    assert response.status_code == 200
+    assert calls == [True]
+    assert response.headers["x-cv-source"] == "mock"
+
+
+def test_cv_analyze_body_override_when_env_false(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CV_MOCK", "false")
+    reset_settings_cache()
+    calls = _patch_cv(monkeypatch)
+
+    response = _post_analyze(client, data={"mock": "true"})
+
+    assert response.status_code == 200
+    assert calls == [True]
+    assert response.headers["x-cv-source"] == "mock"


### PR DESCRIPTION
Fixes CV_MOCK handling:
- Env default (CV_MOCK) + per-request override (query/header/body; query wins)
- Removed forced-mock code paths
- Added tests covering both directions (env vs override)
- No contract changes for clients

------
https://chatgpt.com/codex/tasks/task_e_68dad858913c8326b1b168d38001ac9c