### PR TITLE
feat: add OpenTelemetry spans and golden regression gate

### DIFF
--- a/.github/workflows/golden-regression.yml
+++ b/.github/workflows/golden-regression.yml
@@ -1,0 +1,26 @@
+name: golden-regression
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  golden:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt || true
+          pip install -r requirements-dev.txt
+      - name: Run golden regression tests
+        run: pytest -q tests/golden/test_backview_golden.py

--- a/cv_engine/pipeline/analyze.py
+++ b/cv_engine/pipeline/analyze.py
@@ -1,15 +1,20 @@
 from __future__ import annotations
 
 # isort: skip_file
-import numpy as np
+import os
+from time import perf_counter
 from typing import Any, Dict, Iterable, List, Tuple
 
-from .types import Box
-from .inference.yolo8 import YoloV8Detector
+import numpy as np
+
+from observability.otel import span
+
+from .calibration.simple import as_dict, measure_from_tracks
 from .impact.detector import ImpactDetector
+from .inference.yolo8 import YoloV8Detector
 from .metrics.kinematics import CalibrationParams
-from .calibration.simple import measure_from_tracks, as_dict
 from .metrics.smoothing import moving_average
+from .types import Box
 
 
 def _centers_by_label(boxes: List[Box]) -> Dict[str, List[Tuple[float, float]]]:
@@ -44,44 +49,123 @@ def analyze_frames(
     boxes_per_frame: List[List[Box]] = []
     ball_track: List[Tuple[float, float]] = []
     club_track: List[Tuple[float, float]] = []
+    metrics: Dict[str, Any]
+    events: List[int] = []
+    confidence = 0.0
 
-    for fr in frames_list:
-        boxes = det.run(fr)
-        boxes_per_frame.append(boxes)
-        centers = _centers_by_label(boxes)
-        if centers["ball"]:
-            ball_track.append(centers["ball"][0])
-        if centers["club"]:
-            club_track.append(centers["club"][0])
+    tracker_name = "centroid"
+    pose_backend = os.getenv("GOLFIQ_POSE_BACKEND", "none") or "none"
+    input_size = "0x0"
+    if frames_list:
+        h, w = frames_list[0].shape[:2]
+        input_size = f"{w}x{h}"
 
-    if smoothing_window > 1:
-        ball_track = moving_average(ball_track, smoothing_window)
-        club_track = moving_average(club_track, smoothing_window)
+    timings: Dict[str, float] = {}
 
-    # Reuse boxes for impact; do not call YOLO again
-    impact_events = ImpactDetector(detector=det).run_with_boxes(
-        frames_list, boxes_per_frame
-    )
-    events = [e.frame_index for e in impact_events]
-    confidence = max((e.confidence for e in impact_events), default=0.0)
+    with span(
+        "cv.pipeline.analyze",
+        attributes={
+            "cv.frames_total": len(frames_list),
+            "cv.tracker": tracker_name,
+            "cv.pose_backend": pose_backend,
+            "cv.input_size": input_size,
+        },
+    ) as pipeline_span:
+        detection_start = perf_counter()
+        with span(
+            "cv.pipeline.detection",
+            attributes={
+                "cv.frames_total": len(frames_list),
+                "cv.detector.mock": bool(det.mock),
+            },
+        ) as detection_span:
+            for fr in frames_list:
+                boxes = det.run(fr)
+                boxes_per_frame.append(boxes)
+            if detection_span is not None and frames_list:
+                detection_span.set_attribute(
+                    "cv.detections.total",
+                    sum(len(b) for b in boxes_per_frame),
+                )
+        timings["detection_ms"] = (perf_counter() - detection_start) * 1000.0
 
-    if len(ball_track) < 2 or len(club_track) < 2:
-        metrics = {
-            "ball_speed_mps": 0.0,
-            "ball_speed_mph": 0.0,
-            "club_speed_mps": 0.0,
-            "club_speed_mph": 0.0,
-            "launch_deg": 0.0,
-            "carry_m": 0.0,
-            "metrics_version": 1,
-            "spin_rpm": None,
-            "spin_axis_deg": None,
-            "club_path_deg": None,
-            "confidence": confidence,
-        }
-        return {"events": events, "metrics": metrics}
+        tracking_start = perf_counter()
+        with span(
+            "cv.pipeline.tracking",
+            attributes={"cv.tracker": tracker_name},
+        ) as tracking_span:
+            for boxes in boxes_per_frame:
+                centers = _centers_by_label(boxes)
+                if centers["ball"]:
+                    ball_track.append(centers["ball"][0])
+                if centers["club"]:
+                    club_track.append(centers["club"][0])
 
-    m = measure_from_tracks(ball_track, club_track, calib)
-    metrics = as_dict(m, include_spin_placeholders=True)
-    metrics["confidence"] = confidence
+            if smoothing_window > 1:
+                ball_track = moving_average(ball_track, smoothing_window)
+                club_track = moving_average(club_track, smoothing_window)
+
+            if tracking_span is not None:
+                tracking_span.set_attribute("cv.track.ball.len", len(ball_track))
+                tracking_span.set_attribute("cv.track.club.len", len(club_track))
+        timings["tracking_ms"] = (perf_counter() - tracking_start) * 1000.0
+
+        pose_start = perf_counter()
+        with span(
+            "cv.pipeline.pose",
+            attributes={"cv.pose.backend": pose_backend},
+        ) as pose_span:
+            if pose_span is not None:
+                pose_span.set_attribute("cv.pose.enabled", pose_backend != "none")
+        timings["pose_ms"] = (perf_counter() - pose_start) * 1000.0
+
+        kinematics_start = perf_counter()
+        with span("cv.pipeline.kinematics") as kinematics_span:
+            if len(ball_track) < 2 or len(club_track) < 2:
+                metrics = {
+                    "ball_speed_mps": 0.0,
+                    "ball_speed_mph": 0.0,
+                    "club_speed_mps": 0.0,
+                    "club_speed_mph": 0.0,
+                    "launch_deg": 0.0,
+                    "carry_m": 0.0,
+                    "metrics_version": 1,
+                    "spin_rpm": None,
+                    "spin_axis_deg": None,
+                    "club_path_deg": None,
+                }
+                has_tracks = False
+            else:
+                m = measure_from_tracks(ball_track, club_track, calib)
+                metrics = as_dict(m, include_spin_placeholders=True)
+                has_tracks = True
+            if kinematics_span is not None:
+                kinematics_span.set_attribute("cv.kinematics.has_tracks", has_tracks)
+        timings["kinematics_ms"] = (perf_counter() - kinematics_start) * 1000.0
+
+        impact_start = perf_counter()
+        with span("cv.pipeline.impact") as impact_span:
+            impact_events = ImpactDetector(detector=det).run_with_boxes(
+                frames_list, boxes_per_frame
+            )
+            events = [e.frame_index for e in impact_events]
+            confidence = max((e.confidence for e in impact_events), default=0.0)
+            if impact_span is not None:
+                impact_span.set_attribute("cv.impact.events", len(events))
+                impact_span.set_attribute("cv.impact.confidence", confidence)
+        timings["impact_ms"] = (perf_counter() - impact_start) * 1000.0
+
+        postproc_start = perf_counter()
+        with span("cv.pipeline.postproc") as postproc_span:
+            metrics["confidence"] = confidence
+            if postproc_span is not None:
+                postproc_span.set_attribute("cv.metrics.confidence", confidence)
+        timings["postproc_ms"] = (perf_counter() - postproc_start) * 1000.0
+
+        if pipeline_span is not None:
+            for key, value in timings.items():
+                pipeline_span.set_attribute(f"cv.timings.{key}", round(value, 3))
+            pipeline_span.set_attribute("cv.events.total", len(events))
+            pipeline_span.set_attribute("cv.impact.confidence", confidence)
+
     return {"events": events, "metrics": metrics}

--- a/docs/golden-regression.md
+++ b/docs/golden-regression.md
@@ -1,0 +1,26 @@
+# Golden Regression Gate
+
+The `tests/golden/test_backview_golden.py` suite protects the CV metrics against
+unexpected drift. It runs a mock-backed pipeline on a deterministic synthetic
+clip that is generated at runtime and compares the results with a stored golden
+reference.
+
+## Thresholds
+
+- `ballSpeedMps`: ±3% relative tolerance
+- `sideAngleDeg`: ±1.5° absolute tolerance
+- `carryEstM`: ±12 m absolute tolerance
+
+When a change exceeds the tolerance the GitHub Actions job will fail, preventing
+regressions from landing unnoticed.
+
+## Local execution
+
+```bash
+pip install -r requirements-dev.txt
+pytest tests/golden/test_backview_golden.py
+```
+
+Use this test when modifying detection, tracking, or kinematics logic. Update
+the `tests/assets/backview_golden_metrics.json` file only when a change is
+intentional and validated.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,60 @@
+# Observability & OpenTelemetry
+
+The CV pipeline emits OpenTelemetry spans when tracing is enabled. This makes it
+possible to inspect latency in Grafana/Tempo or to debug locally with the
+console exporter.
+
+## Enabling tracing
+
+Set the following environment variables before starting any process that invokes
+`cv_engine.pipeline.analyze.analyze_frames`:
+
+- `GOLFIQ_OTEL_ENABLED=1` &ndash; turns on span creation.
+- `GOLFIQ_OTEL_EXPORTER=otlp` (default) or `console` &ndash; choose the exporter.
+- `OTEL_EXPORTER_OTLP_ENDPOINT` &ndash; point to your OTLP collector when using the
+  OTLP exporter.
+- Optional: `GOLFIQ_OTEL_SCOPE`, `OTEL_SERVICE_NAME`, `OTEL_SERVICE_NAMESPACE`,
+  and `GOLFIQ_ENV` to customise service metadata.
+
+When the OpenTelemetry SDK or requested exporter is not available the code
+falls back to a noop tracer, so enabling tracing in environments without the
+SDK is safe.
+
+## Instrumented spans
+
+`analyze_frames` now wraps the major CV stages with nested spans:
+
+- `cv.pipeline.analyze` (root span) &ndash; carries attributes such as
+  `cv.frames_total`, tracker backend, pose backend, and per-stage timings in
+  milliseconds.
+- `cv.pipeline.detection`
+- `cv.pipeline.tracking`
+- `cv.pipeline.pose`
+- `cv.pipeline.kinematics`
+- `cv.pipeline.impact`
+- `cv.pipeline.postproc`
+
+Each span exposes useful attributes: detection reports the number of boxes,
+tracking spans record the track lengths, impact spans emit the detected impact
+count and confidence, and post-processing carries the final confidence value.
+
+## Example trace
+
+```bash
+export GOLFIQ_OTEL_ENABLED=1
+export GOLFIQ_OTEL_EXPORTER=console
+python - <<'PY'
+import numpy as np
+from cv_engine.metrics.kinematics import CalibrationParams
+from cv_engine.pipeline.analyze import analyze_frames
+
+# Generate a tiny synthetic clip (identical to the golden regression fixture)
+frames = np.zeros((12, 120, 160, 3), dtype=np.uint8)
+calib = CalibrationParams(m_per_px=0.01, fps=120.0)
+analyze_frames(frames, calib, mock=True)
+PY
+```
+
+With the console exporter you will see the nested spans, including the per-stage
+attributes and timings, printed to stdout. Switch to the OTLP exporter to ship
+traces to your collector of choice.

--- a/observability/__init__.py
+++ b/observability/__init__.py
@@ -1,0 +1,3 @@
+"""Observability helpers."""
+
+from .otel import is_tracing_enabled, span, tracer  # noqa: F401

--- a/observability/otel.py
+++ b/observability/otel.py
@@ -1,0 +1,158 @@
+"""OpenTelemetry helper utilities for GolfIQ CV pipeline."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import os
+from typing import Any, Mapping, MutableMapping
+
+__all__ = ["is_tracing_enabled", "span", "tracer"]
+
+
+class _NullContextManager:
+    def __enter__(self) -> None:  # noqa: D401 - simple noop
+        return None
+
+    def __exit__(self, exc_type, exc, tb) -> bool:  # type: ignore[override]
+        return False
+
+
+class _NullTracer:
+    def start_as_current_span(
+        self, name: str, *, attributes: Mapping[str, Any] | None = None
+    ) -> _NullContextManager:
+        return _NullContextManager()
+
+
+_TRACER: Any | None = None
+
+_FLAG_ENV_VARS = ("GOLFIQ_OTEL_ENABLED", "OTEL_GOLFIQ_ENABLED")
+_DEFAULT_SCOPE = "golfiq.cv.pipeline"
+
+
+def is_tracing_enabled() -> bool:
+    """Return True when OTEL tracing should be enabled for the process."""
+
+    for name in _FLAG_ENV_VARS:
+        value = os.getenv(name)
+        if value is None:
+            continue
+        if value.strip().lower() in {"1", "true", "yes", "on"}:
+            return True
+        return False
+    return False
+
+
+def tracer() -> Any:
+    """Return a configured tracer (or a noop tracer when disabled)."""
+
+    global _TRACER
+    if _TRACER is not None:
+        return _TRACER
+
+    if not is_tracing_enabled():
+        _TRACER = _NullTracer()
+        return _TRACER
+
+    if not _otel_dependencies_present():
+        _TRACER = _NullTracer()
+        return _TRACER
+
+    _TRACER = _build_tracer()
+    return _TRACER
+
+
+def span(name: str, *, attributes: Mapping[str, Any] | None = None):
+    """Context manager that yields an OTEL span when tracing is enabled."""
+
+    current_tracer = tracer()
+    if isinstance(current_tracer, _NullTracer):
+        return _NullContextManager()
+    return current_tracer.start_as_current_span(name, attributes=attributes)
+
+
+def _otel_dependencies_present() -> bool:
+    required = [
+        "opentelemetry",  # core API
+        "opentelemetry.trace",
+        "opentelemetry.sdk.trace",
+        "opentelemetry.sdk.trace.export",
+        "opentelemetry.sdk.resources",
+    ]
+    for module_name in required:
+        if importlib.util.find_spec(module_name) is None:
+            return False
+    exporter_choice = os.getenv("GOLFIQ_OTEL_EXPORTER", "otlp").strip().lower()
+    if exporter_choice == "console":
+        return True
+    http_spec = importlib.util.find_spec(
+        "opentelemetry.exporter.otlp.proto.http.trace_exporter"
+    )
+    grpc_spec = importlib.util.find_spec(
+        "opentelemetry.exporter.otlp.proto.grpc.trace_exporter"
+    )
+    return http_spec is not None or grpc_spec is not None
+
+
+def _build_tracer() -> Any:
+    from opentelemetry import trace as trace_api
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import (
+        BatchSpanProcessor,
+        ConsoleSpanExporter,
+        SimpleSpanProcessor,
+    )
+
+    instrumentation_scope = os.getenv("GOLFIQ_OTEL_SCOPE", _DEFAULT_SCOPE)
+
+    existing_provider = trace_api.get_tracer_provider()
+    if isinstance(existing_provider, TracerProvider) and getattr(
+        existing_provider, "_golfiq_configured", False
+    ):
+        return trace_api.get_tracer(instrumentation_scope)
+
+    exporter = _select_exporter()
+    if exporter is None:
+        return _NullTracer()
+
+    resource_attributes: MutableMapping[str, Any] = {
+        "service.name": os.getenv("OTEL_SERVICE_NAME", "golfiq-cv"),
+        "service.namespace": os.getenv("OTEL_SERVICE_NAMESPACE", "golfiq"),
+        "service.instance.id": os.getenv("HOSTNAME", "local"),
+    }
+    deployment_env = os.getenv("GOLFIQ_ENV")
+    if deployment_env:
+        resource_attributes["deployment.environment"] = deployment_env
+
+    provider = TracerProvider(resource=Resource.create(resource_attributes))
+
+    exporter_choice = os.getenv("GOLFIQ_OTEL_EXPORTER", "otlp").strip().lower()
+    if exporter_choice == "console":
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+    else:
+        provider.add_span_processor(BatchSpanProcessor(exporter))
+
+    provider._golfiq_configured = True  # type: ignore[attr-defined]
+    trace_api.set_tracer_provider(provider)
+    return trace_api.get_tracer(instrumentation_scope)
+
+
+def _select_exporter():
+    exporter_choice = os.getenv("GOLFIQ_OTEL_EXPORTER", "otlp").strip().lower()
+    if exporter_choice == "console":
+        from opentelemetry.sdk.trace.export import ConsoleSpanExporter
+
+        return ConsoleSpanExporter()
+
+    http_module_name = "opentelemetry.exporter.otlp.proto.http.trace_exporter"
+    grpc_module_name = "opentelemetry.exporter.otlp.proto.grpc.trace_exporter"
+
+    if importlib.util.find_spec(http_module_name) is not None:
+        http_module = importlib.import_module(http_module_name)
+        return http_module.OTLPSpanExporter()
+    if importlib.util.find_spec(grpc_module_name) is not None:
+        grpc_module = importlib.import_module(grpc_module_name)
+        return grpc_module.OTLPSpanExporter()
+    return None

--- a/tests/assets/backview_golden_metrics.json
+++ b/tests/assets/backview_golden_metrics.json
@@ -1,0 +1,5 @@
+{
+  "ballSpeedMps": 2.91,
+  "sideAngleDeg": 63.43,
+  "carryEstM": 0.8
+}

--- a/tests/golden/test_backview_golden.py
+++ b/tests/golden/test_backview_golden.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+
+from cv_engine.inference.yolo8 import YoloV8Detector
+from cv_engine.metrics.kinematics import CalibrationParams
+from cv_engine.pipeline.analyze import _centers_by_label, analyze_frames
+
+ASSETS_DIR = Path(__file__).resolve().parents[1] / "assets"
+METRICS_PATH = ASSETS_DIR / "backview_golden_metrics.json"
+
+
+def _generate_golden_frames(frame_count: int = 12) -> np.ndarray:
+    """Generate a deterministic synthetic clip for golden regression."""
+
+    height, width = 120, 160
+    frames = np.zeros((frame_count, height, width, 3), dtype=np.uint8)
+    for idx in range(frame_count):
+        frame = frames[idx]
+        # Draw a tiny "ball" patch that loosely follows the mock detector path so
+        # we still exercise rendering code paths if visualized when debugging.
+        cx = min(width - 3, max(0, int(width * 0.48) + idx * 2))
+        cy = min(height - 3, max(0, int(height * 0.52) - idx))
+        frame[cy : cy + 3, cx : cx + 3] = 255
+    return frames
+
+
+def _compute_side_angle_deg(frames: Sequence[np.ndarray]) -> float:
+    detector = YoloV8Detector(mock=True)
+    boxes_per_frame = [detector.run(frame) for frame in frames]
+    track = []
+    for boxes in boxes_per_frame:
+        centers = _centers_by_label(boxes)
+        if centers["ball"]:
+            track.append(centers["ball"][0])
+    if len(track) < 2:
+        return 0.0
+    (x0, y0), (x1, y1) = track[0], track[-1]
+    dx = x1 - x0
+    dy = y1 - y0
+    return math.degrees(math.atan2(dx, abs(dy) + 1e-6))
+
+
+def test_backview_pipeline_golden_regression() -> None:
+    frames = _generate_golden_frames()
+    with METRICS_PATH.open("r", encoding="utf-8") as fh:
+        expected = json.load(fh)
+
+    calib = CalibrationParams(m_per_px=0.01, fps=120.0)
+    result = analyze_frames(frames, calib, mock=True)
+    metrics = result["metrics"]
+
+    ball_speed_mps = metrics["ball_speed_mps"]
+    side_angle_deg = _compute_side_angle_deg(frames)
+    carry_est_m = metrics["carry_m"]
+
+    assert abs(ball_speed_mps - expected["ballSpeedMps"]) <= expected["ballSpeedMps"] * 0.03
+    assert abs(side_angle_deg - expected["sideAngleDeg"]) <= 1.5
+    assert abs(carry_est_m - expected["carryEstM"]) <= 12.0


### PR DESCRIPTION
## Summary
- OTel spans for CV stages + CI golden-regression (speed/angle/carry)

## Notes
- Env-controlled tracing; golden clip generated at runtime to avoid binary assets; non-breaking

------
https://chatgpt.com/codex/tasks/task_e_68dfdddd96a4832688613d6058f7a08f