### PR TITLE
feat: add mobile thermal/battery fallback policy

### DIFF
--- a/android/bench/src/main/java/com/golfiq/bench/policy/ThermalBatteryPolicy.kt
+++ b/android/bench/src/main/java/com/golfiq/bench/policy/ThermalBatteryPolicy.kt
@@ -1,0 +1,267 @@
+package com.golfiq.bench.policy
+
+import android.content.Context
+import android.os.BatteryManager
+import android.os.Build
+import android.os.PowerManager
+import android.os.SystemClock
+import android.util.Log
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import com.golfiq.bench.telemetry.TelemetryClient
+import com.golfiq.bench.telemetry.ThermalBatterySample
+import java.time.Duration
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.math.max
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+class ThermalBatteryPolicy(
+    private val context: Context,
+    private val telemetryClient: TelemetryClient,
+    private val telemetryScope: CoroutineScope,
+    private val listener: Listener,
+    private val config: Config = Config(),
+    private val elapsedRealtime: () -> Long = { SystemClock.elapsedRealtime() },
+    private val wallClock: () -> Long = { System.currentTimeMillis() },
+) : DefaultLifecycleObserver {
+
+    data class Config(
+        val sampleInterval: Duration = Duration.ofSeconds(60),
+        val batteryWindow: Duration = Duration.ofMinutes(15),
+        val batteryDropThresholdPercent: Double = 9.0,
+        val severeThermalStatus: Int = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            PowerManager.THERMAL_STATUS_SEVERE
+        } else {
+            Int.MAX_VALUE
+        },
+    )
+
+    enum class Trigger { THERMAL, BATTERY, USER }
+
+    enum class PolicyAction {
+        NONE,
+        SWITCH_TO_2D,
+        REDUCE_REFRESH,
+        PAUSE_HEAVY_FEATURES,
+        RESUME_REQUESTED,
+    }
+
+    interface Listener {
+        fun onPolicyApplied(action: PolicyAction, trigger: Trigger)
+        fun onPolicyCleared()
+    }
+
+    private data class BatterySample(val timestamp: Long, val percent: Int)
+
+    private val scheduler = Executors.newSingleThreadScheduledExecutor { runnable ->
+        Thread(runnable, "golfiq-thermal-battery").apply { isDaemon = true }
+    }
+    private var scheduledTask: ScheduledFuture<*>? = null
+    private val batterySamples = ArrayDeque<BatterySample>()
+    private val running = AtomicBoolean(false)
+
+    private val powerManager: PowerManager? = context.getSystemService(PowerManager::class.java)
+    private val batteryManager: BatteryManager? = context.getSystemService(BatteryManager::class.java)
+
+    private var lastThermalStatus: Int? = currentThermalStatus()
+    private var latestBatteryPercent: Int? = null
+    private var latestBatteryDelta: Double? = null
+    private var activeAction: PolicyAction = PolicyAction.NONE
+    private var activeTrigger: Trigger? = null
+
+    private val thermalListener = PowerManager.OnThermalStatusChangedListener { status ->
+        handleThermalStatus(status)
+    }
+
+    override fun onStart(owner: LifecycleOwner) {
+        start()
+    }
+
+    override fun onStop(owner: LifecycleOwner) {
+        stop()
+    }
+
+    fun start() {
+        if (!running.compareAndSet(false, true)) {
+            return
+        }
+        registerThermalListener()
+        scheduleBatterySampling()
+    }
+
+    fun stop() {
+        if (!running.compareAndSet(true, false)) {
+            return
+        }
+        unregisterThermalListener()
+        scheduledTask?.cancel(true)
+        scheduledTask = null
+        batterySamples.clear()
+        latestBatteryPercent = null
+        latestBatteryDelta = null
+        if (activeAction != PolicyAction.NONE) {
+            listener.onPolicyCleared()
+        }
+        activeAction = PolicyAction.NONE
+        activeTrigger = null
+    }
+
+    fun requestResumeFromFallback() {
+        if (activeAction == PolicyAction.NONE) {
+            listener.onPolicyCleared()
+            emitTelemetry(PolicyAction.NONE, Trigger.USER)
+            return
+        }
+        activeAction = PolicyAction.RESUME_REQUESTED
+        activeTrigger = Trigger.USER
+        listener.onPolicyCleared()
+        emitTelemetry(PolicyAction.RESUME_REQUESTED, Trigger.USER)
+        activeAction = PolicyAction.NONE
+        activeTrigger = null
+    }
+
+    private fun registerThermalListener() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            return
+        }
+        val manager = powerManager ?: return
+        runCatching {
+            manager.addThermalStatusListener(ContextCompat.getMainExecutor(context), thermalListener)
+            lastThermalStatus = manager.currentThermalStatus
+            lastThermalStatus?.let { status ->
+                if (status >= config.severeThermalStatus) {
+                    applyPolicy(PolicyAction.SWITCH_TO_2D, Trigger.THERMAL)
+                }
+                emitTelemetry(activeAction, Trigger.THERMAL)
+            }
+        }.onFailure { throwable ->
+            Log.w(TAG, "Unable to register thermal listener", throwable)
+        }
+    }
+
+    private fun unregisterThermalListener() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            return
+        }
+        val manager = powerManager ?: return
+        runCatching {
+            manager.removeThermalStatusListener(thermalListener)
+        }.onFailure { throwable ->
+            Log.w(TAG, "Unable to unregister thermal listener", throwable)
+        }
+    }
+
+    private fun handleThermalStatus(status: Int) {
+        lastThermalStatus = status
+        if (status >= config.severeThermalStatus) {
+            applyPolicy(PolicyAction.SWITCH_TO_2D, Trigger.THERMAL)
+        }
+        emitTelemetry(activeAction, Trigger.THERMAL)
+    }
+
+    private fun scheduleBatterySampling() {
+        if (batteryManager == null) {
+            return
+        }
+        val intervalMillis = max(config.sampleInterval.toMillis(), 1L)
+        scheduledTask = scheduler.scheduleAtFixedRate(
+            { sampleBattery() },
+            0L,
+            intervalMillis,
+            TimeUnit.MILLISECONDS,
+        )
+    }
+
+    private fun sampleBattery() {
+        val manager = batteryManager ?: return
+        val level = manager.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY)
+        if (level == Int.MIN_VALUE) {
+            return
+        }
+        val now = elapsedRealtime()
+        latestBatteryPercent = level
+        synchronized(batterySamples) {
+            batterySamples += BatterySample(now, level)
+            trimBatterySamples(now)
+            latestBatteryDelta = computeBatteryDeltaLocked()
+        }
+        latestBatteryDelta?.let { delta ->
+            when {
+                delta >= config.batteryDropThresholdPercent * 1.5 ->
+                    applyPolicy(PolicyAction.PAUSE_HEAVY_FEATURES, Trigger.BATTERY)
+                delta >= config.batteryDropThresholdPercent ->
+                    if (activeAction != PolicyAction.PAUSE_HEAVY_FEATURES) {
+                        applyPolicy(PolicyAction.REDUCE_REFRESH, Trigger.BATTERY)
+                    }
+            }
+        }
+        if ((latestBatteryDelta ?: 0.0) < config.batteryDropThresholdPercent * 0.5 &&
+            activeTrigger == Trigger.BATTERY &&
+            activeAction != PolicyAction.NONE
+        ) {
+            activeAction = PolicyAction.NONE
+            activeTrigger = null
+            listener.onPolicyCleared()
+        }
+        emitTelemetry(activeAction, Trigger.BATTERY)
+    }
+
+    private fun trimBatterySamples(now: Long) {
+        val windowMillis = config.batteryWindow.toMillis()
+        while (batterySamples.isNotEmpty() && now - batterySamples.first().timestamp > windowMillis) {
+            batterySamples.removeFirst()
+        }
+    }
+
+    private fun computeBatteryDeltaLocked(): Double? {
+        if (batterySamples.size < 2) {
+            return 0.0
+        }
+        val newest = batterySamples.last()
+        val oldest = batterySamples.first()
+        return max(0.0, (oldest.percent - newest.percent).toDouble())
+    }
+
+    private fun applyPolicy(action: PolicyAction, trigger: Trigger) {
+        if (activeAction == action) {
+            return
+        }
+        activeAction = action
+        activeTrigger = trigger
+        listener.onPolicyApplied(action, trigger)
+    }
+
+    private fun emitTelemetry(action: PolicyAction, trigger: Trigger) {
+        if (!running.get()) {
+            return
+        }
+        val sample = ThermalBatterySample(
+            timestampMs = wallClock(),
+            thermalStatus = lastThermalStatus,
+            batteryPercent = latestBatteryPercent,
+            batteryDeltaPercent = latestBatteryDelta,
+            action = action.name.lowercase(),
+            trigger = trigger.name.lowercase(),
+        )
+        telemetryScope.launch {
+            telemetryClient.postPolicySamples(listOf(sample))
+        }
+    }
+
+    private fun currentThermalStatus(): Int? {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            powerManager?.currentThermalStatus
+        } else {
+            null
+        }
+    }
+
+    companion object {
+        private const val TAG = "ThermalBatteryPolicy"
+    }
+}

--- a/android/bench/src/main/java/com/golfiq/bench/telemetry/TelemetryClient.kt
+++ b/android/bench/src/main/java/com/golfiq/bench/telemetry/TelemetryClient.kt
@@ -17,11 +17,17 @@ class TelemetryClient(context: Context) {
 
     suspend fun postBatch(payloads: List<TelemetryPayload>) {
         if (payloads.isEmpty()) return
+        postJsonArray(JSONArray().apply { payloads.forEach { put(it.toJson()) } })
+    }
+
+    suspend fun postPolicySamples(samples: List<ThermalBatterySample>) {
+        if (samples.isEmpty()) return
+        postJsonArray(JSONArray().apply { samples.forEach { put(it.toJson()) } })
+    }
+
+    private suspend fun postJsonArray(array: JSONArray) {
         withContext(Dispatchers.IO) {
-            val json = JSONArray().apply {
-                payloads.forEach { put(it.toJson()) }
-            }
-            val body = json.toString().toRequestBody(JSON.toMediaType())
+            val body = array.toString().toRequestBody(JSON.toMediaType())
             val request = Request.Builder().url(endpoint).post(body).build()
             runCatching { httpClient.newCall(request).execute() }
                 .onFailure { Log.e(TAG, "Telemetry POST failed", it) }

--- a/android/bench/src/main/java/com/golfiq/bench/telemetry/ThermalBatterySample.kt
+++ b/android/bench/src/main/java/com/golfiq/bench/telemetry/ThermalBatterySample.kt
@@ -1,0 +1,24 @@
+package com.golfiq.bench.telemetry
+
+import org.json.JSONObject
+
+data class ThermalBatterySample(
+    val timestampMs: Long,
+    val thermalStatus: Int?,
+    val batteryPercent: Int?,
+    val batteryDeltaPercent: Double?,
+    val action: String,
+    val trigger: String,
+) {
+    fun toJson(): JSONObject = JSONObject().apply {
+        put("type", "thermal_battery_sample")
+        put("timestamp_ms", timestampMs)
+        thermalStatus?.let { put("thermal_status", it) }
+        batteryPercent?.let { put("battery_percent", it) }
+        batteryDeltaPercent?.let { put("battery_delta_percent", it) }
+        put("policy_action", action)
+        put("trigger", trigger)
+        put("device", android.os.Build.MODEL ?: "unknown")
+        put("api_level", android.os.Build.VERSION.SDK_INT)
+    }
+}

--- a/android/bench/src/main/java/com/golfiq/bench/ui/MainActivity.kt
+++ b/android/bench/src/main/java/com/golfiq/bench/ui/MainActivity.kt
@@ -1,12 +1,16 @@
 package com.golfiq.bench.ui
 
 import android.os.Bundle
+import android.view.View
 import android.widget.TextView
 import androidx.activity.ComponentActivity
 import androidx.lifecycle.lifecycleScope
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.card.MaterialCardView
 import com.golfiq.bench.R
 import com.golfiq.bench.config.BenchmarkConfig
 import com.golfiq.bench.data.FrameRepository
+import com.golfiq.bench.policy.ThermalBatteryPolicy
 import com.golfiq.bench.runtime.RuntimeFactory
 import com.golfiq.bench.telemetry.TelemetryClient
 import com.golfiq.bench.telemetry.TelemetryPayload
@@ -16,17 +20,40 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlin.io.use
 
-class MainActivity : ComponentActivity() {
+class MainActivity : ComponentActivity(), ThermalBatteryPolicy.Listener {
+    private lateinit var status: TextView
+    private lateinit var summary: TextView
+    private lateinit var telemetryClient: TelemetryClient
+    private lateinit var protectionBanner: MaterialCardView
+    private lateinit var protectionBannerText: TextView
+    private lateinit var protectionBannerAction: MaterialButton
+    private lateinit var policy: ThermalBatteryPolicy
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
-        val status = findViewById<TextView>(R.id.statusText)
-        val summary = findViewById<TextView>(R.id.summaryText)
+        status = findViewById(R.id.statusText)
+        summary = findViewById(R.id.summaryText)
+        protectionBanner = findViewById(R.id.protectionBanner)
+        protectionBannerText = findViewById(R.id.protectionBannerText)
+        protectionBannerAction = findViewById(R.id.protectionBannerAction)
         val config = BenchmarkConfig.fromIntent(intent)
+
+        telemetryClient = TelemetryClient(this)
+        policy = ThermalBatteryPolicy(
+            context = this,
+            telemetryClient = telemetryClient,
+            telemetryScope = lifecycleScope,
+            listener = this,
+        )
+        lifecycle.addObserver(policy)
+
+        protectionBannerAction.setOnClickListener {
+            policy.requestResumeFromFallback()
+        }
 
         lifecycleScope.launch {
             status.setText(R.string.bench_status_running)
-            val telemetryClient = TelemetryClient(this@MainActivity)
             val frames = withContext(Dispatchers.IO) {
                 FrameRepository(this@MainActivity).load()
             }
@@ -53,6 +80,35 @@ class MainActivity : ComponentActivity() {
                 val statusLabel = payload.status.name.lowercase()
                 "${payload.runtime} [$statusLabel]: fps=${"%.1f".format(payload.metrics.fpsAvg)} p50=${payload.metrics.latencyP50Ms}ms"
             }
+        }
+    }
+
+    override fun onPolicyApplied(
+        action: ThermalBatteryPolicy.PolicyAction,
+        trigger: ThermalBatteryPolicy.Trigger,
+    ) {
+        when (action) {
+            ThermalBatteryPolicy.PolicyAction.SWITCH_TO_2D -> showProtectionBanner()
+            ThermalBatteryPolicy.PolicyAction.REDUCE_REFRESH -> status.text =
+                getString(R.string.protection_status_battery)
+            ThermalBatteryPolicy.PolicyAction.PAUSE_HEAVY_FEATURES -> status.text =
+                getString(R.string.protection_status_heavy_features)
+            ThermalBatteryPolicy.PolicyAction.RESUME_REQUESTED,
+            ThermalBatteryPolicy.PolicyAction.NONE -> Unit
+        }
+    }
+
+    override fun onPolicyCleared() {
+        protectionBanner.visibility = View.GONE
+        if (status.text != getString(R.string.bench_status_done)) {
+            status.setText(R.string.bench_status_running)
+        }
+    }
+
+    private fun showProtectionBanner() {
+        if (protectionBanner.visibility != View.VISIBLE) {
+            protectionBanner.visibility = View.VISIBLE
+            protectionBanner.announceForAccessibility(protectionBannerText.text)
         }
     }
 }

--- a/android/bench/src/main/res/layout/activity_main.xml
+++ b/android/bench/src/main/res/layout/activity_main.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -15,6 +16,44 @@
         android:text="@string/bench_status_idle"
         android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
         android:textColor="@color/white" />
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/protectionBanner"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:visibility="gone"
+        app:cardBackgroundColor="#1E2A2A"
+        app:cardCornerRadius="12dp"
+        app:cardElevation="0dp"
+        app:strokeColor="@color/teal_200"
+        app:strokeWidth="1dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:padding="16dp"
+            android:baselineAligned="false">
+
+            <TextView
+                android:id="@+id/protectionBannerText"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/protection_banner_message"
+                android:textColor="@color/white"
+                android:textSize="14sp" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/protectionBannerAction"
+                style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/protection_banner_resume" />
+        </LinearLayout>
+    </com.google.android.material.card.MaterialCardView>
 
     <TextView
         android:id="@+id/summaryText"

--- a/android/bench/src/main/res/values/strings.xml
+++ b/android/bench/src/main/res/values/strings.xml
@@ -3,4 +3,8 @@
     <string name="bench_status_idle">Ready to run runtime benchmarks.</string>
     <string name="bench_status_running">Running benchmarks…</string>
     <string name="bench_status_done">Benchmarks complete.</string>
+    <string name="protection_banner_message">Battery/thermal protection: switched to 2D.</string>
+    <string name="protection_banner_resume">Try resume HUD</string>
+    <string name="protection_status_battery">Battery protection active — reducing HUD refresh rate.</string>
+    <string name="protection_status_heavy_features">Battery protection active — heavy HUD features paused.</string>
 </resources>

--- a/docs/mobile-thermal-policy.md
+++ b/docs/mobile-thermal-policy.md
@@ -1,0 +1,48 @@
+# Mobile Thermal & Battery Protection Policy
+
+This document describes the lightweight thermal and battery watchdog that guards the GolfIQ AR HUD and live detection experiences.
+
+## Goals
+
+* Detect hazardous device thermal conditions early and drop to a safe 2D compass rendering mode.
+* Monitor short-term battery drain while the HUD/live pipeline is active and throttle heavy workloads when drain is excessive.
+* Stream telemetry snapshots to `/telemetry` so back-end dashboards can visualise mitigation frequency and tune thresholds remotely.
+
+## Default thresholds
+
+| Metric | Threshold | Action |
+| --- | --- | --- |
+| Thermal state | `SEVERE` / `serious` or worse | Immediately switch HUD to 2D compass mode, surface the protection banner, and emit telemetry with `policy_action = switch_to_2d`. |
+| Battery drain | > 9% drop across any 15 minute window | Reduce HUD refresh cadence (Android: throttle updates; iOS: lower sample rate) and emit telemetry with `policy_action = reduce_refresh`. |
+| Battery drain (escalated) | > 13.5% drop (1.5x threshold) over the same window | Pause heavy HUD features (dense inference/audio) and emit telemetry with `policy_action = pause_heavy_features`. |
+
+Telemetry samples are emitted every 60 seconds while monitoring is active. Each sample contains:
+
+* Unix timestamp (`timestamp_ms`),
+* Latest thermal status,
+* Battery percentage and 15 minute delta,
+* Applied policy action and trigger (`thermal`, `battery`, or `user`).
+
+## Platform notes
+
+### Android
+
+* Uses `PowerManager.currentThermalStatus` via `ThermalBatteryPolicy` with a 60 second scheduled sampler.
+* Battery data comes from `BatteryManager.BATTERY_PROPERTY_CAPACITY` and is kept in a rolling window for slope estimation.
+* Telemetry posts to `/telemetry` immediately using the bench client; failures log but do not crash the HUD.
+* UI banner lives in `activity_main.xml` and exposes a "Try resume HUD" action that calls back into the policy.
+
+### iOS
+
+* Observes `ProcessInfo.thermalState` and `UIDevice.batteryLevel` via the `ThermalBatteryPolicy` service.
+* Sampling uses a `DispatchSourceTimer` on a serial queue; telemetry is appended to `TelemetryClient.policySamples` for upload.
+* A SwiftUI `ThermalProtectionBanner` mirrors the Android UX.
+
+## Tuning guidance
+
+1. **Sampling interval** – increase beyond 60s for slower devices, decrease if you need tighter thermal response. Beware radio/CPU cost when sampling too frequently.
+2. **Battery window** – the 15 minute window matches our session length goals. Adjust via the `Config` objects if field data shows false positives.
+3. **Policy actions** – attach additional delegates to `ThermalBatteryPolicy` to toggle feature flags (audio, 3D overlays) progressively.
+4. **Telemetry** – dashboards should group by `policy_action` to identify noisy mitigations. Consider shipping server-side overrides once enough signal is collected.
+
+To override thresholds per build, supply custom `Config` values when wiring the policies, or feed remote config into those constructors during app bootstrap.

--- a/ios/App/UI/ThermalProtectionBanner.swift
+++ b/ios/App/UI/ThermalProtectionBanner.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+struct ThermalProtectionBanner: View {
+    let isVisible: Bool
+    let message: String
+    let onResume: () -> Void
+
+    var body: some View {
+        if isVisible {
+            HStack(spacing: 12) {
+                Text(message)
+                    .font(.callout)
+                    .foregroundStyle(Color.white)
+                    .multilineTextAlignment(.leading)
+                Spacer()
+                Button(action: onResume) {
+                    Text("Try resume HUD")
+                        .font(.subheadline)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.teal)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background(Color(red: 0.12, green: 0.16, blue: 0.16))
+            .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .stroke(Color.teal.opacity(0.6), lineWidth: 1)
+            )
+            .padding(.horizontal, 16)
+            .transition(.move(edge: .top).combined(with: .opacity))
+            .animation(.easeInOut(duration: 0.25), value: isVisible)
+        }
+    }
+}
+
+#Preview {
+    ThermalProtectionBanner(isVisible: true, message: "Battery/thermal protection: switched to 2D.") {}
+        .background(Color.black)
+}

--- a/ios/Services/TelemetryClient.swift
+++ b/ios/Services/TelemetryClient.swift
@@ -16,9 +16,19 @@ final class TelemetryClient {
         let activeRuntime: String
     }
 
+    struct PolicySample: Codable {
+        let timestamp: Date
+        let thermalState: String
+        let batteryPercent: Double?
+        let batteryDeltaPercent: Double?
+        let action: String
+        let trigger: String
+    }
+
     private(set) var metrics: [MetricRecord] = []
     private(set) var deviceProfiles: [DeviceProfilePayload] = []
     private(set) var impactTriggerCount: Int = 0
+    private(set) var policySamples: [PolicySample] = []
 
     func emit(name: String, value: Double, deviceClass: String, sampled: Bool) {
         metrics.append(MetricRecord(name: name, value: value, deviceClass: deviceClass, sampled: sampled))
@@ -39,5 +49,9 @@ final class TelemetryClient {
     func logImpactTriggerEvent(magnitudeDb: Double) {
         impactTriggerCount += 1
         emit(name: "impact_trigger", value: magnitudeDb, deviceClass: "audio", sampled: true)
+    }
+
+    func postPolicySample(_ sample: PolicySample) {
+        policySamples.append(sample)
     }
 }

--- a/ios/Services/ThermalBatteryPolicy.swift
+++ b/ios/Services/ThermalBatteryPolicy.swift
@@ -1,0 +1,235 @@
+import Foundation
+import UIKit
+
+protocol ThermalBatteryPolicyDelegate: AnyObject {
+    func policyDidApply(action: ThermalBatteryPolicy.PolicyAction, trigger: ThermalBatteryPolicy.Trigger)
+    func policyDidClearMitigations()
+}
+
+final class ThermalBatteryPolicy {
+    struct Config {
+        var sampleInterval: TimeInterval = 60
+        var batteryWindow: TimeInterval = 15 * 60
+        var batteryDropThresholdPercent: Double = 9
+    }
+
+    enum PolicyAction: String {
+        case none
+        case switchTo2D
+        case reduceRefresh
+        case pauseHeavyFeatures
+        case resumeRequested
+    }
+
+    enum Trigger: String {
+        case thermal
+        case battery
+        case user
+    }
+
+    private struct BatterySample {
+        let timestamp: Date
+        let percent: Double
+    }
+
+    private let telemetry: TelemetryClient
+    private let config: Config
+    private let queue = DispatchQueue(label: "com.golfiq.policy.thermal-battery")
+    private var timer: DispatchSourceTimer?
+    private var batteryHistory: [BatterySample] = []
+    private var latestBatteryDelta: Double?
+    private var activeAction: PolicyAction = .none
+    private var activeTrigger: Trigger?
+    private var isRunning = false
+    private var thermalObserver: NSObjectProtocol?
+
+    weak var delegate: ThermalBatteryPolicyDelegate?
+
+    init(telemetry: TelemetryClient, config: Config = Config()) {
+        self.telemetry = telemetry
+        self.config = config
+    }
+
+    deinit {
+        stop()
+    }
+
+    func start() {
+        queue.sync {
+            guard !isRunning else { return }
+            isRunning = true
+            batteryHistory.removeAll()
+            latestBatteryDelta = nil
+            UIDevice.current.isBatteryMonitoringEnabled = true
+            scheduleTimerLocked()
+        }
+        observeThermalState()
+        queue.async { [weak self] in
+            self?.emitTelemetry(trigger: .thermal)
+        }
+    }
+
+    func stop() {
+        var shouldClear = false
+        queue.sync {
+            guard isRunning else { return }
+            isRunning = false
+            timer?.cancel()
+            timer = nil
+            batteryHistory.removeAll()
+            latestBatteryDelta = nil
+            shouldClear = activeAction != .none
+            activeAction = .none
+            activeTrigger = nil
+            UIDevice.current.isBatteryMonitoringEnabled = false
+        }
+        if let observer = thermalObserver {
+            NotificationCenter.default.removeObserver(observer)
+            thermalObserver = nil
+        }
+        if shouldClear {
+            DispatchQueue.main.async { [weak self] in
+                self?.delegate?.policyDidClearMitigations()
+            }
+        }
+    }
+
+    func requestResumeFromFallback() {
+        queue.async { [weak self] in
+            guard let self else { return }
+            if !self.isRunning {
+                return
+            }
+            if self.activeAction == .none {
+                DispatchQueue.main.async {
+                    self.delegate?.policyDidClearMitigations()
+                }
+                self.emitTelemetry(trigger: .user)
+                return
+            }
+            self.activeAction = .resumeRequested
+            self.activeTrigger = .user
+            DispatchQueue.main.async {
+                self.delegate?.policyDidClearMitigations()
+            }
+            self.emitTelemetry(trigger: .user)
+            self.activeAction = .none
+            self.activeTrigger = nil
+        }
+    }
+
+    private func scheduleTimerLocked() {
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(deadline: .now(), repeating: config.sampleInterval)
+        timer.setEventHandler { [weak self] in
+            self?.sampleBattery()
+        }
+        timer.resume()
+        self.timer = timer
+    }
+
+    private func observeThermalState() {
+        let center = NotificationCenter.default
+        thermalObserver = center.addObserver(forName: ProcessInfo.thermalStateDidChangeNotification, object: nil, queue: nil) { [weak self] _ in
+            let state = ProcessInfo.processInfo.thermalState
+            self?.queue.async {
+                self?.handleThermalState(state)
+            }
+        }
+        queue.async { [weak self] in
+            guard let self else { return }
+            self.handleThermalState(ProcessInfo.processInfo.thermalState)
+        }
+    }
+
+    private func handleThermalState(_ state: ProcessInfo.ThermalState) {
+        if state.rawValue >= ProcessInfo.ThermalState.serious.rawValue {
+            apply(action: .switchTo2D, trigger: .thermal)
+        }
+        emitTelemetry(trigger: .thermal)
+    }
+
+    private func sampleBattery() {
+        let level = UIDevice.current.batteryLevel
+        guard level >= 0 else { return }
+        let percent = Double(level) * 100
+        let now = Date()
+        batteryHistory.append(BatterySample(timestamp: now, percent: percent))
+        trimBatteryHistory(now: now)
+        latestBatteryDelta = computeBatteryDelta()
+        if let delta = latestBatteryDelta {
+            if delta >= config.batteryDropThresholdPercent * 1.5 {
+                apply(action: .pauseHeavyFeatures, trigger: .battery)
+            } else if delta >= config.batteryDropThresholdPercent {
+                if activeAction != .pauseHeavyFeatures {
+                    apply(action: .reduceRefresh, trigger: .battery)
+                }
+            } else if activeTrigger == .battery && activeAction != .none {
+                activeAction = .none
+                activeTrigger = nil
+                DispatchQueue.main.async { [weak self] in
+                    self?.delegate?.policyDidClearMitigations()
+                }
+            }
+        }
+        emitTelemetry(trigger: .battery)
+    }
+
+    private func trimBatteryHistory(now: Date) {
+        let cutoff = now.addingTimeInterval(-config.batteryWindow)
+        batteryHistory.removeAll { sample in
+            sample.timestamp < cutoff
+        }
+    }
+
+    private func computeBatteryDelta() -> Double? {
+        guard let oldest = batteryHistory.first, let newest = batteryHistory.last else {
+            return nil
+        }
+        return max(0, oldest.percent - newest.percent)
+    }
+
+    private func apply(action: PolicyAction, trigger: Trigger) {
+        if activeAction == action { return }
+        activeAction = action
+        activeTrigger = trigger
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.delegate?.policyDidApply(action: action, trigger: trigger)
+        }
+    }
+
+    private func emitTelemetry(trigger: Trigger) {
+        guard isRunning else { return }
+        let sample = TelemetryClient.PolicySample(
+            timestamp: Date(),
+            thermalState: describe(ProcessInfo.processInfo.thermalState),
+            batteryPercent: currentBatteryPercent(),
+            batteryDeltaPercent: latestBatteryDelta,
+            action: activeAction.rawValue,
+            trigger: trigger.rawValue
+        )
+        telemetry.postPolicySample(sample)
+    }
+
+    private func currentBatteryPercent() -> Double? {
+        let level = UIDevice.current.batteryLevel
+        guard level >= 0 else { return nil }
+        return Double(level) * 100
+    }
+
+    private func describe(_ state: ProcessInfo.ThermalState) -> String {
+        switch state {
+        case .nominal:
+            return "nominal"
+        case .fair:
+            return "fair"
+        case .serious:
+            return "serious"
+        case .critical:
+            return "critical"
+        @unknown default:
+            return "unknown"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Thermal/battery protection for AR/live detection with graceful fallback
## Thresholds
- Defaults: <=9%/15min battery, no SEVERE/CRITICAL thermal

------
https://chatgpt.com/codex/tasks/task_e_68e0143f4778832693abaf1b28b4011b