### PR TITLE
feat(web): export traced video

### DIFF
--- a/docs/export-traced-video.md
+++ b/docs/export-traced-video.md
@@ -1,0 +1,27 @@
+# Export traced video
+
+The web app now offers a client-side export flow that replays a run's back-view
+video with the tracer overlay and optional telemetry metrics rendered directly
+onto a canvas. The frames are captured locally with `MediaRecorder` and
+assembled into a downloadable clip.
+
+## Browser support
+
+| Browser | Container | Notes |
+| --- | --- | --- |
+| Chrome / Edge | WebM (VP9/VP8) | Best experience. MP4 (H.264) is attempted when supported by `MediaRecorder`. |
+| Firefox | WebM (VP9/VP8) | Works, though MP4 is not available. |
+| Safari (macOS / iOS) | Limited | Safari 16+ exposes `MediaRecorder`, but H.264 recording support is inconsistent. Prefer Chrome when possible. |
+
+The export runs entirely in the browser—no video data is uploaded to the
+server. Large recordings can produce sizable blobs; we stream `MediaRecorder`
+chunks every second to avoid building the entire recording in memory before the
+download is ready.
+
+## Troubleshooting
+
+- If the download prompts for WebM and you require MP4, please switch to the
+  latest Chrome/Edge build, which advertises H.264 support via
+  `MediaRecorder.isTypeSupported`.
+- Very old browsers without `MediaRecorder` will surface an in-app error. In
+  those cases, instruct the user to try Chrome on desktop for the export.

--- a/web/src/components/ExportPanel.tsx
+++ b/web/src/components/ExportPanel.tsx
@@ -1,0 +1,303 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { TraceData } from "../lib/traceUtils";
+import {
+  MetricOverlay,
+  drawMetricsOverlay,
+  drawTraceOverlay,
+  setupRecorder,
+  startFramePump,
+  waitForPlaybackEnd,
+  waitForVideoMetadata,
+} from "../lib/exportUtils";
+
+type ExportState = "idle" | "preparing" | "recording" | "complete" | "error" | "canceled";
+
+interface ExportPanelProps {
+  isOpen: boolean;
+  onClose: () => void;
+  runId?: string | null;
+  videoUrl?: string | null;
+  trace?: TraceData | null;
+  metrics?: MetricOverlay[];
+}
+
+const noop = () => {};
+
+const formatSize = (bytes: number) => {
+  if (bytes < 1024) return `${bytes.toFixed(0)} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+};
+
+export default function ExportPanel({ isOpen, onClose, runId, videoUrl, trace, metrics = [] }: ExportPanelProps) {
+  const [includeMetrics, setIncludeMetrics] = useState(metrics.length > 0);
+  const [state, setState] = useState<ExportState>("idle");
+  const [progress, setProgress] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [downloadUrl, setDownloadUrl] = useState<string | null>(null);
+  const [downloadName, setDownloadName] = useState<string | null>(null);
+  const [mimeType, setMimeType] = useState<string | null>(null);
+  const [bytesRecorded, setBytesRecorded] = useState(0);
+  const abortRef = useRef<() => void>(noop);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setState("idle");
+      setProgress(0);
+      setError(null);
+      setDownloadUrl((prev) => {
+        if (prev) {
+          URL.revokeObjectURL(prev);
+        }
+        return null;
+      });
+      setDownloadName(null);
+      setMimeType(null);
+      setBytesRecorded(0);
+    } else {
+      setIncludeMetrics(metrics.length > 0);
+    }
+  }, [isOpen, metrics.length]);
+
+  useEffect(() => () => {
+    if (downloadUrl) {
+      URL.revokeObjectURL(downloadUrl);
+    }
+  }, [downloadUrl]);
+
+  const handleClose = useCallback(() => {
+    if (state === "recording" || state === "preparing") {
+      abortRef.current();
+    }
+    onClose();
+  }, [state, onClose]);
+
+  const startExport = useCallback(async () => {
+    if (!videoUrl) {
+      setError("No video available for this run");
+      return;
+    }
+    try {
+      setState("preparing");
+      setProgress(0);
+      setError(null);
+      setBytesRecorded(0);
+
+      const video = document.createElement("video");
+      video.crossOrigin = "anonymous";
+      video.src = videoUrl;
+      video.muted = true;
+      video.playsInline = true;
+      video.preload = "auto";
+
+      await waitForVideoMetadata(video);
+
+      const width = video.videoWidth;
+      const height = video.videoHeight;
+
+      if (!width || !height) {
+        throw new Error("Unable to read video dimensions");
+      }
+
+      video.currentTime = 0;
+
+      const canvas = document.createElement("canvas");
+      canvas.width = width;
+      canvas.height = height;
+      const ctx = canvas.getContext("2d", { alpha: false });
+
+      if (!ctx) {
+        throw new Error("Failed to create drawing context");
+      }
+
+      const { recorder, mimeType: selectedMime } = setupRecorder(canvas, {
+        preferMp4: true,
+        videoBitsPerSecond: Math.min(12_000_000, width * height * 12),
+      });
+
+      setMimeType(selectedMime);
+
+      const chunks: Blob[] = [];
+      let stopped = false;
+      let canceled = false;
+
+      recorder.ondataavailable = (event) => {
+        if (!event.data || !event.data.size) return;
+        chunks.push(event.data);
+        setBytesRecorded((value) => value + event.data.size);
+      };
+
+      const finalize = () => {
+        if (stopped) return;
+        stopped = true;
+        recorder.stop();
+      };
+
+      abortRef.current = () => {
+        stopped = true;
+        canceled = true;
+        try {
+          recorder.stop();
+        } catch (err) {
+          console.warn("Error stopping recorder", err);
+        }
+        video.pause();
+        setState("canceled");
+      };
+
+      const drawFrame = () => {
+        ctx.drawImage(video, 0, 0, width, height);
+        if (trace) {
+          drawTraceOverlay(ctx, trace, width, height);
+        }
+        if (includeMetrics && metrics.length) {
+          drawMetricsOverlay(ctx, metrics, width);
+        }
+        if (video.duration) {
+          setProgress(Math.min(video.currentTime / video.duration, 1));
+        }
+      };
+
+      setState("recording");
+      const recorderStopPromise = new Promise<void>((resolve) => {
+        recorder.addEventListener("stop", () => resolve(), { once: true });
+      });
+
+      recorder.start(1000);
+
+      const stopPump = startFramePump(video, drawFrame);
+
+      const playbackPromise = waitForPlaybackEnd(video).finally(() => {
+        stopPump();
+        drawFrame();
+        finalize();
+      });
+
+      await video.play();
+      drawFrame();
+
+      await playbackPromise;
+
+      await recorderStopPromise;
+
+      if (canceled) {
+        return;
+      }
+
+      const blob = new Blob(chunks, { type: selectedMime });
+      const url = URL.createObjectURL(blob);
+      const extension = selectedMime.includes("mp4") ? "mp4" : "webm";
+      const filename = `run_${runId ?? "unknown"}_traced.${extension}`;
+      setDownloadUrl(url);
+      setDownloadName(filename);
+      setState("complete");
+      setProgress(1);
+    } catch (err) {
+      console.error("Export failed", err);
+      setError(err instanceof Error ? err.message : "Failed to export traced video");
+      setState("error");
+    }
+  }, [includeMetrics, metrics, runId, state, trace, videoUrl]);
+
+  const canStart = state === "idle" || state === "error" || state === "canceled" || state === "complete";
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/70 backdrop-blur-sm">
+      <div className="w-full max-w-xl rounded-xl border border-slate-800 bg-slate-900 p-6 shadow-2xl">
+        <header className="mb-4 flex items-center justify-between">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-100">Export traced video</h2>
+            <p className="text-xs text-slate-400">Replay the run with tracer overlay and download a shareable clip.</p>
+          </div>
+          <button
+            type="button"
+            onClick={handleClose}
+            className="rounded-md border border-slate-700 px-3 py-1 text-xs text-slate-300 hover:bg-slate-800"
+          >
+            Close
+          </button>
+        </header>
+
+        <section className="space-y-4 text-sm text-slate-300">
+          <div className="space-y-1">
+            <div className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-500">
+              <span>Resolution</span>
+              <span className="text-slate-400">Match source</span>
+            </div>
+            <p className="text-xs text-slate-500">
+              Video will export at the original resolution ({" "}
+              <span className="font-mono text-slate-300">source</span> ).
+            </p>
+          </div>
+
+          <label
+            className={`flex items-center gap-3 rounded-lg border border-slate-800 bg-slate-900/60 p-3 text-xs text-slate-300 ${
+              metrics.length ? "" : "opacity-60"
+            }`}
+          >
+            <input
+              type="checkbox"
+              checked={includeMetrics}
+              onChange={(event) => setIncludeMetrics(event.target.checked)}
+              disabled={!metrics.length}
+              className="h-4 w-4 rounded border-slate-700 bg-slate-900 text-emerald-400 focus:ring-emerald-500 disabled:cursor-not-allowed"
+            />
+            Include metrics overlay
+            {!metrics.length && <span className="text-[0.65rem] uppercase tracking-wide text-slate-500">Not available</span>}
+          </label>
+
+          {error && <p className="rounded-md border border-red-500/40 bg-red-500/10 p-2 text-xs text-red-200">{error}</p>}
+
+          <div className="space-y-2">
+            <div className="h-2 w-full overflow-hidden rounded-full bg-slate-800">
+              <div
+                className="h-full rounded-full bg-emerald-400 transition-all"
+                style={{ width: `${Math.round(progress * 100)}%` }}
+              />
+            </div>
+            <div className="flex justify-between text-xs text-slate-400">
+              <span>{state === "recording" ? "Exporting…" : state === "complete" ? "Complete" : "Idle"}</span>
+              {bytesRecorded > 0 && <span>{formatSize(bytesRecorded)}</span>}
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between gap-2">
+            <button
+              type="button"
+              className="rounded-md border border-emerald-500/50 bg-emerald-500/10 px-4 py-2 text-xs font-semibold text-emerald-200 transition hover:bg-emerald-500/20 disabled:cursor-not-allowed disabled:opacity-60"
+              onClick={startExport}
+              disabled={!canStart || !videoUrl}
+            >
+              {state === "recording" || state === "preparing" ? "Exporting…" : "Start Export"}
+            </button>
+
+            {(state === "recording" || state === "preparing") && (
+              <button
+                type="button"
+                className="rounded-md border border-slate-700 px-3 py-2 text-xs text-slate-300 hover:bg-slate-800"
+                onClick={() => abortRef.current()}
+              >
+                Cancel
+              </button>
+            )}
+
+            {downloadUrl && state === "complete" && (
+              <a
+                href={downloadUrl}
+                download={downloadName ?? undefined}
+                className="ml-auto inline-flex items-center gap-2 rounded-md border border-sky-500/40 bg-sky-500/10 px-4 py-2 text-xs font-semibold text-sky-200 transition hover:bg-sky-500/20"
+              >
+                Download ({mimeType?.includes("mp4") ? "MP4" : "WebM"})
+              </a>
+            )}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}
+

--- a/web/src/lib/exportUtils.ts
+++ b/web/src/lib/exportUtils.ts
@@ -1,0 +1,307 @@
+import { TraceData, createSmoothPath, mapPointToCanvas, getBounds } from "./traceUtils";
+
+type RecorderPreference = {
+  preferMp4?: boolean;
+  videoBitsPerSecond?: number;
+};
+
+const MIME_CANDIDATES = [
+  "video/webm;codecs=vp9",
+  "video/webm;codecs=vp8",
+  "video/webm",
+  "video/mp4;codecs=avc1.42E01E,mp4a.40.2",
+  "video/mp4",
+];
+
+export const pickSupportedMimeType = (preferMp4 = false): string | null => {
+  if (typeof window === "undefined" || typeof MediaRecorder === "undefined") {
+    return null;
+  }
+
+  const ordered = preferMp4
+    ? [...MIME_CANDIDATES.filter((type) => type.includes("mp4")), ...MIME_CANDIDATES.filter((type) => !type.includes("mp4"))]
+    : MIME_CANDIDATES;
+
+  for (const type of ordered) {
+    if (MediaRecorder.isTypeSupported(type)) {
+      return type;
+    }
+  }
+
+  return null;
+};
+
+export const setupRecorder = (
+  canvas: HTMLCanvasElement,
+  preference: RecorderPreference = {}
+): { recorder: MediaRecorder; mimeType: string } => {
+  if (typeof MediaRecorder === "undefined") {
+    throw new Error("MediaRecorder API is not supported in this browser");
+  }
+
+  const stream = canvas.captureStream();
+  const mimeType = pickSupportedMimeType(preference.preferMp4) ?? "video/webm";
+  const options: MediaRecorderOptions = { mimeType };
+  if (preference.videoBitsPerSecond) {
+    options.videoBitsPerSecond = preference.videoBitsPerSecond;
+  }
+  const recorder = new MediaRecorder(stream, options);
+  return { recorder, mimeType };
+};
+
+export const waitForVideoMetadata = (video: HTMLVideoElement): Promise<void> =>
+  new Promise((resolve, reject) => {
+    if (video.readyState >= 1 && video.videoWidth > 0 && video.videoHeight > 0) {
+      resolve();
+      return;
+    }
+    const onLoaded = () => {
+      cleanup();
+      resolve();
+    };
+    const onError = (event: Event) => {
+      cleanup();
+      reject(event instanceof ErrorEvent ? event.error : new Error("Failed to load video metadata"));
+    };
+    const cleanup = () => {
+      video.removeEventListener("loadedmetadata", onLoaded);
+      video.removeEventListener("error", onError);
+    };
+    video.addEventListener("loadedmetadata", onLoaded, { once: true });
+    video.addEventListener("error", onError, { once: true });
+  });
+
+export const waitForPlaybackEnd = (video: HTMLVideoElement): Promise<void> =>
+  new Promise((resolve) => {
+    if (video.ended) {
+      resolve();
+      return;
+    }
+    const onEnded = () => {
+      cleanup();
+      resolve();
+    };
+    const onError = () => {
+      cleanup();
+      resolve();
+    };
+    const cleanup = () => {
+      video.removeEventListener("ended", onEnded);
+      video.removeEventListener("error", onError);
+    };
+    video.addEventListener("ended", onEnded, { once: true });
+    video.addEventListener("error", onError, { once: true });
+  });
+
+type FrameCallback = (metadata?: VideoFrameCallbackMetadata) => void;
+
+export const startFramePump = (video: HTMLVideoElement, callback: FrameCallback): (() => void) => {
+  let stopped = false;
+
+  const draw = () => {
+    if (stopped) return;
+    callback();
+  };
+
+  const typedVideo = video as HTMLVideoElement & {
+    requestVideoFrameCallback?: (callback: VideoFrameRequestCallback) => number;
+    cancelVideoFrameCallback?: (handle: number) => void;
+  };
+
+  if (typeof typedVideo.requestVideoFrameCallback === "function" && typeof typedVideo.cancelVideoFrameCallback === "function") {
+    let handle: number;
+    const step = (_now: number, metadata: VideoFrameCallbackMetadata) => {
+      if (stopped) return;
+      callback(metadata);
+      handle = typedVideo.requestVideoFrameCallback!(step);
+    };
+    handle = typedVideo.requestVideoFrameCallback(step);
+    return () => {
+      stopped = true;
+      if (handle) {
+        typedVideo.cancelVideoFrameCallback!(handle);
+      }
+    };
+  }
+
+  let rafId = 0;
+  const pump = () => {
+    if (stopped) return;
+    draw();
+    if (!video.ended && !video.paused) {
+      rafId = window.requestAnimationFrame(pump);
+    }
+  };
+
+  const onPlay = () => {
+    if (stopped) return;
+    rafId = window.requestAnimationFrame(pump);
+  };
+
+  video.addEventListener("play", onPlay);
+  if (!video.paused) {
+    onPlay();
+  }
+
+  const onEnded = () => {
+    draw();
+  };
+
+  video.addEventListener("ended", onEnded, { once: true });
+
+  return () => {
+    stopped = true;
+    if (rafId) {
+      window.cancelAnimationFrame(rafId);
+    }
+    video.removeEventListener("play", onPlay);
+    video.removeEventListener("ended", onEnded);
+  };
+};
+
+export type MetricOverlay = {
+  label: string;
+  value: string;
+  secondary?: string;
+};
+
+const drawRoundedRect = (
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  radius: number
+) => {
+  const r = Math.min(radius, width / 2, height / 2);
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.lineTo(x + width - r, y);
+  ctx.quadraticCurveTo(x + width, y, x + width, y + r);
+  ctx.lineTo(x + width, y + height - r);
+  ctx.quadraticCurveTo(x + width, y + height, x + width - r, y + height);
+  ctx.lineTo(x + r, y + height);
+  ctx.quadraticCurveTo(x, y + height, x, y + height - r);
+  ctx.lineTo(x, y + r);
+  ctx.quadraticCurveTo(x, y, x + r, y);
+  ctx.closePath();
+};
+
+export const drawTraceOverlay = (
+  ctx: CanvasRenderingContext2D,
+  trace: TraceData,
+  canvasWidth: number,
+  canvasHeight: number
+) => {
+  const { mapped, normalized } = createSmoothPath(
+    trace.points ?? [],
+    canvasWidth,
+    canvasHeight,
+    0.2,
+    undefined,
+    trace.normalized
+  );
+
+  if (!mapped.length) {
+    return;
+  }
+
+  ctx.save();
+  const gradient = ctx.createLinearGradient(0, 0, 0, canvasHeight);
+  gradient.addColorStop(0, "#6ee7b7");
+  gradient.addColorStop(0.5, "#34d399");
+  gradient.addColorStop(1, "#10b981");
+  ctx.strokeStyle = gradient;
+  ctx.lineWidth = Math.max(canvasWidth, canvasHeight) / 320;
+  ctx.lineJoin = "round";
+  ctx.lineCap = "round";
+  ctx.beginPath();
+  mapped.forEach((point, index) => {
+    if (index === 0) {
+      ctx.moveTo(point.x, point.y);
+    } else {
+      ctx.lineTo(point.x, point.y);
+    }
+  });
+  ctx.stroke();
+
+  const bounds = trace.normalized ? { minX: 0, maxX: 1, minY: 0, maxY: 1 } : getBounds(trace.points ?? []);
+
+  const markPoint = (index: number | undefined, color: string, label: string) => {
+    if (index === undefined || !trace.points?.[index]) return;
+    const mappedPoint = mapPointToCanvas(trace.points[index], canvasWidth, canvasHeight, bounds, normalized);
+    ctx.fillStyle = color;
+    const radius = Math.max(canvasWidth, canvasHeight) / 90;
+    ctx.beginPath();
+    ctx.arc(mappedPoint.x, mappedPoint.y, radius, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.fillStyle = color;
+    ctx.font = `${Math.max(canvasHeight / 45, 10)}px "Inter", "system-ui"`;
+    ctx.textAlign = "center";
+    ctx.textBaseline = "bottom";
+    ctx.fillText(label, mappedPoint.x, mappedPoint.y - radius * 1.2);
+  };
+
+  markPoint(trace.apexIndex, "#facc15", "Apex");
+  markPoint(trace.landingIndex, "#f97316", "Landing");
+
+  ctx.restore();
+};
+
+export const drawMetricsOverlay = (
+  ctx: CanvasRenderingContext2D,
+  metrics: MetricOverlay[],
+  canvasWidth: number
+) => {
+  if (!metrics.length) return;
+
+  const padding = canvasWidth * 0.015;
+  const cardHeight = canvasWidth * 0.07;
+  const cardWidth = canvasWidth * 0.22;
+  const gap = padding * 0.6;
+  const rows = Math.ceil(metrics.length / 2);
+  const totalHeight = rows * cardHeight + (rows - 1) * gap + padding * 2;
+  const totalWidth = cardWidth * 2 + gap + padding * 2;
+
+  const originX = padding;
+  const originY = padding;
+
+  ctx.save();
+  ctx.globalAlpha = 0.85;
+  drawRoundedRect(ctx, originX - padding * 0.6, originY - padding * 0.6, totalWidth, totalHeight, padding);
+  ctx.fillStyle = "rgba(15, 23, 42, 0.65)";
+  ctx.fill();
+
+  ctx.globalAlpha = 1;
+  ctx.font = `${Math.max(cardHeight * 0.18, 14)}px "Inter", "system-ui"`;
+  ctx.textAlign = "left";
+  ctx.textBaseline = "top";
+
+  metrics.forEach((metric, index) => {
+    const row = Math.floor(index / 2);
+    const col = index % 2;
+    const x = originX + col * (cardWidth + gap);
+    const y = originY + row * (cardHeight + gap);
+
+    drawRoundedRect(ctx, x, y, cardWidth, cardHeight, padding * 0.5);
+    ctx.fillStyle = "rgba(30, 41, 59, 0.85)";
+    ctx.fill();
+
+    ctx.fillStyle = "#bae6fd";
+    ctx.font = `${Math.max(cardHeight * 0.22, 14)}px "Inter", "system-ui"`;
+    ctx.fillText(metric.label, x + padding * 0.6, y + padding * 0.5);
+
+    ctx.fillStyle = "#f8fafc";
+    ctx.font = `${Math.max(cardHeight * 0.32, 18)}px "Inter", "system-ui"`;
+    ctx.fillText(metric.value, x + padding * 0.6, y + padding * 1.4);
+
+    if (metric.secondary) {
+      ctx.fillStyle = "#cbd5f5";
+      ctx.font = `${Math.max(cardHeight * 0.2, 12)}px "Inter", "system-ui"`;
+      ctx.fillText(metric.secondary, x + padding * 0.6, y + cardHeight - padding * 1.2);
+    }
+  });
+
+  ctx.restore();
+};
+


### PR DESCRIPTION
## Summary
- Client-side export of tracer+metrics as WebM/MP4

## Notes
- Pure client; no server/storage impact

------
https://chatgpt.com/codex/tasks/task_e_68e0146be71c8326bf89e32725c99f41