### PR TITLE
feat(coach): server provider + router on main (supersedes #126)

### DIFF
--- a/docs/coach-v1.md
+++ b/docs/coach-v1.md
@@ -1,0 +1,56 @@
+# Coach v1
+
+Coach v1 delivers PGA-style swing insights powered by an interchangeable provider layer. The default implementation calls OpenAI with a function-calling schema that mirrors GolfIQ swing metrics and returns concise markdown-ready feedback.
+
+## Environment variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `COACH_PROVIDER` | `openai` | Selects the provider implementation (`openai` or `mock`). |
+| `OPENAI_API_KEY` | _required_ | API key for OpenAI when using the OpenAI provider. |
+| `OPENAI_MODEL` | `gpt-4o-mini` | Chat completion model used for feedback generation. |
+| `OPENAI_TIMEOUT` | `3` | Timeout in seconds for the OpenAI API call. |
+
+## Swing metrics schema
+
+The OpenAI provider enforces a structured function signature to keep the model grounded in telemetry:
+
+```json
+{
+  "name": "analyze_swing",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "metrics": {
+        "type": "object",
+        "properties": {
+          "ballSpeedMps": { "type": ["number", "null"] },
+          "clubSpeedMps": { "type": ["number", "null"] },
+          "sideAngleDeg": { "type": ["number", "null"] },
+          "vertLaunchDeg": { "type": ["number", "null"] },
+          "carryEstM": { "type": ["number", "null"] },
+          "quality": { "type": ["object", "string", "null"] }
+        },
+        "additionalProperties": true
+      },
+      "feedback": {
+        "type": "string",
+        "description": "Player-facing notes that follow the system prompt"
+      }
+    },
+    "required": ["feedback"]
+  }
+}
+```
+
+## Prompt template
+
+System prompt: _"You are an experienced PGA coach. Be brief, specific, and friendly. Write 4-6 sentences, highlight one strength, one primary focus area, and share two actionable drills."_
+
+User prompt: the serialized swing metrics dictionary for the selected run.
+
+## Error handling
+
+* Calls are time-limited by `OPENAI_TIMEOUT` seconds.
+* Timeouts or provider errors return a friendly fallback string: _"Coach feedback is taking longer than expected. Please try again in a moment."_
+* `/coach/feedback` is rate limited in-memory (5 requests per IP per minute) and responds with HTTP 429 on bursts.

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,6 +1,8 @@
 # --- Staging defaults ---
 OPENAI_API_KEY=
 OPENAI_MODEL=gpt-4o-mini
+OPENAI_TIMEOUT=3
+COACH_PROVIDER=openai
 COACH_FEATURE=false
 
 # YOLO runtime

--- a/server/api/routers/coach_feedback.py
+++ b/server/api/routers/coach_feedback.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import time
+from collections import defaultdict, deque
+from threading import Lock
+from typing import Any, Deque, Dict, Optional
+
+from fastapi import APIRouter, HTTPException, Request, status
+from pydantic import AliasChoices, BaseModel, Field, model_validator
+
+from server.services.coach import generate_feedback
+from server.storage.runs import load_run
+
+router = APIRouter(tags=["coach"])
+
+_RATE_LIMIT_WINDOW_SEC = 60.0
+_RATE_LIMIT_MAX_REQUESTS = 5
+_rate_buckets: Dict[str, Deque[float]] = defaultdict(deque)
+_rate_lock = Lock()
+
+
+class CoachFeedbackRequest(BaseModel):
+    run_id: Optional[str] = Field(
+        default=None,
+        alias="run_id",
+        validation_alias=AliasChoices("run_id", "runId"),
+    )
+    metrics: Optional[Dict[str, Any]] = None
+
+    model_config = {
+        "populate_by_name": True,
+    }
+
+    @model_validator(mode="after")
+    def validate_payload(self) -> "CoachFeedbackRequest":
+        if not self.run_id and not self.metrics:
+            raise ValueError("Provide either run_id or metrics")
+        return self
+
+
+class CoachFeedbackResponse(BaseModel):
+    text: str
+    provider: str
+    latency_ms: int
+
+
+def _rate_limit(ip: str) -> None:
+    now = time.monotonic()
+    with _rate_lock:
+        bucket = _rate_buckets[ip]
+        while bucket and now - bucket[0] > _RATE_LIMIT_WINDOW_SEC:
+            bucket.popleft()
+        if len(bucket) >= _RATE_LIMIT_MAX_REQUESTS:
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail="Too many coach feedback requests",
+            )
+        bucket.append(now)
+
+
+@router.post("/coach/feedback", response_model=CoachFeedbackResponse)
+async def coach_feedback(
+    request: Request, body: CoachFeedbackRequest
+) -> CoachFeedbackResponse:
+    client = request.client.host if request.client else "unknown"
+    _rate_limit(client)
+
+    metrics: Dict[str, Any] = {}
+    if body.run_id:
+        record = load_run(body.run_id)
+        if record is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Run not found"
+            )
+        if isinstance(record.metrics, dict):
+            metrics = dict(record.metrics)
+    if body.metrics:
+        if not isinstance(body.metrics, dict):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="metrics must be an object",
+            )
+        metrics.update(body.metrics)
+
+    result = generate_feedback(metrics)
+    return CoachFeedbackResponse(**result)

--- a/server/app.py
+++ b/server/app.py
@@ -14,6 +14,7 @@ from server.api.health import health as _health_handler
 from server.api.routers import calibrate as legacy_calibrate
 from server.api.routers import metrics
 from server.api.routers.coach import router as coach_router
+from server.api.routers.coach_feedback import router as coach_feedback_router
 from server.metrics import MetricsMiddleware, metrics_app
 from server.retention.sweeper import sweep_retention_once
 
@@ -89,6 +90,7 @@ app.add_middleware(MetricsMiddleware)
 api_dep = _api_key_dependency()
 
 app.include_router(coach_router)
+app.include_router(coach_feedback_router)
 app.include_router(legacy_calibrate.router)
 app.include_router(calibrate_router)
 app.include_router(caddie_router)

--- a/server/services/coach/__init__.py
+++ b/server/services/coach/__init__.py
@@ -1,0 +1,5 @@
+"""Coach service package."""
+
+from .service import generate_feedback, FALLBACK_TEXT
+
+__all__ = ["generate_feedback", "FALLBACK_TEXT"]

--- a/server/services/coach/providers/__init__.py
+++ b/server/services/coach/providers/__init__.py
@@ -1,0 +1,13 @@
+"""Coach provider implementations."""
+
+from .base import CoachProvider, CoachProviderError, CoachProviderTimeout
+from .mock_provider import MockCoachProvider
+from .openai_provider import OpenAICoachProvider
+
+__all__ = [
+    "CoachProvider",
+    "CoachProviderError",
+    "CoachProviderTimeout",
+    "MockCoachProvider",
+    "OpenAICoachProvider",
+]

--- a/server/services/coach/providers/base.py
+++ b/server/services/coach/providers/base.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import abc
+from typing import Any, Mapping
+
+
+class CoachProviderError(Exception):
+    """Base error raised by coach providers."""
+
+
+class CoachProviderTimeout(CoachProviderError):
+    """Raised when a provider exceeds its timeout budget."""
+
+
+class CoachProvider(abc.ABC):
+    """Interface for coach feedback providers."""
+
+    name: str = "provider"
+
+    @abc.abstractmethod
+    def generate(self, metrics: Mapping[str, Any]) -> str:
+        """Generate feedback for the supplied swing metrics."""

--- a/server/services/coach/providers/mock_provider.py
+++ b/server/services/coach/providers/mock_provider.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from .base import CoachProvider
+
+
+class MockCoachProvider(CoachProvider):
+    """Deterministic mock provider for local development and tests."""
+
+    name = "mock"
+
+    _TEXT = (
+        "Solid strike overall. Keep the tempo smooth and stay tall through impact. "
+        "Focus on matching club and ball speed windows, then repeat with two alignment-rod drills."
+    )
+
+    def generate(self, metrics: Mapping[str, Any]) -> str:
+        return self._TEXT

--- a/server/services/coach/providers/openai_provider.py
+++ b/server/services/coach/providers/openai_provider.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Mapping
+
+import httpx
+
+from .base import CoachProvider, CoachProviderError, CoachProviderTimeout
+
+_SYSTEM_PROMPT = (
+    "You are an experienced PGA coach. Be brief, specific, and friendly. "
+    "Write 4-6 sentences, highlight one strength, one primary focus area, "
+    "and share two actionable drills."
+)
+
+_FUNCTION_DEFINITION = {
+    "name": "analyze_swing",
+    "description": (
+        "Craft actionable golf swing feedback based on the supplied "
+        "launch monitor metrics."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "metrics": {
+                "type": "object",
+                "properties": {
+                    "ballSpeedMps": {
+                        "type": ["number", "null"],
+                        "description": "Ball speed in meters per second.",
+                    },
+                    "clubSpeedMps": {
+                        "type": ["number", "null"],
+                        "description": "Club head speed in meters per second.",
+                    },
+                    "sideAngleDeg": {
+                        "type": ["number", "null"],
+                        "description": "Side angle at launch in degrees.",
+                    },
+                    "vertLaunchDeg": {
+                        "type": ["number", "null"],
+                        "description": "Vertical launch angle in degrees.",
+                    },
+                    "carryEstM": {
+                        "type": ["number", "null"],
+                        "description": "Estimated carry distance in meters.",
+                    },
+                    "quality": {
+                        "type": ["object", "string", "null"],
+                        "description": "Quality markers or tags returned by the analyzer.",
+                        "additionalProperties": True,
+                    },
+                },
+                "additionalProperties": True,
+            },
+            "feedback": {
+                "type": "string",
+                "description": "Player-facing feedback following the system instructions.",
+            },
+        },
+        "required": ["feedback"],
+    },
+}
+
+
+class OpenAICoachProvider(CoachProvider):
+    name = "openai"
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        model: str | None = None,
+        timeout: float | None = None,
+        http_client: httpx.Client | None = None,
+    ) -> None:
+        self._api_key = api_key or os.getenv("OPENAI_API_KEY")
+        self._model = model or os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+        timeout_env = os.getenv("OPENAI_TIMEOUT")
+        self._timeout = timeout if timeout is not None else float(timeout_env or 3.0)
+        self._client = http_client
+
+    def _post(self, payload: Mapping[str, Any]) -> httpx.Response:
+        headers = {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+        }
+        if not self._api_key:
+            raise CoachProviderError("OPENAI_API_KEY is not configured")
+        client = self._client
+        try:
+            if client is not None:
+                return client.post(
+                    "/chat/completions",
+                    json=payload,
+                    headers=headers,
+                    timeout=self._timeout,
+                )
+            return httpx.post(
+                "https://api.openai.com/v1/chat/completions",
+                json=payload,
+                headers=headers,
+                timeout=self._timeout,
+            )
+        except httpx.TimeoutException as exc:
+            raise CoachProviderTimeout("OpenAI request timed out") from exc
+        except httpx.HTTPError as exc:
+            raise CoachProviderError("OpenAI request failed") from exc
+
+    def generate(self, metrics: Mapping[str, Any]) -> str:
+        payload = {
+            "model": self._model,
+            "messages": [
+                {"role": "system", "content": _SYSTEM_PROMPT},
+                {
+                    "role": "user",
+                    "content": (
+                        "Analyze the swing metrics below and produce feedback. "
+                        "Return friendly, specific coaching notes.\n\n"
+                        + json.dumps(dict(metrics), ensure_ascii=False)
+                    ),
+                },
+            ],
+            "tools": [{"type": "function", "function": _FUNCTION_DEFINITION}],
+            "tool_choice": {"type": "function", "function": {"name": "analyze_swing"}},
+            "temperature": 0.2,
+            "max_tokens": 400,
+        }
+
+        response = self._post(payload)
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            raise CoachProviderError("OpenAI responded with an error") from exc
+
+        data = response.json()
+        choices = data.get("choices") or []
+        if not choices:
+            raise CoachProviderError("OpenAI response missing choices")
+        message = choices[0].get("message") or {}
+        tool_calls = message.get("tool_calls") or []
+        if tool_calls:
+            try:
+                arguments = tool_calls[0]["function"]["arguments"]
+            except (KeyError, TypeError) as exc:
+                raise CoachProviderError("Malformed function call from OpenAI") from exc
+            try:
+                parsed = json.loads(arguments)
+            except json.JSONDecodeError as exc:
+                raise CoachProviderError(
+                    "Invalid JSON in OpenAI function arguments"
+                ) from exc
+            feedback = parsed.get("feedback")
+            if isinstance(feedback, str) and feedback.strip():
+                return feedback.strip()
+        content = message.get("content")
+        if isinstance(content, str) and content.strip():
+            return content.strip()
+        raise CoachProviderError("OpenAI did not return feedback text")

--- a/server/services/coach/service.py
+++ b/server/services/coach/service.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import os
+import time
+from typing import Any, Mapping
+
+import httpx
+
+from .providers import (
+    CoachProvider,
+    CoachProviderError,
+    CoachProviderTimeout,
+    MockCoachProvider,
+    OpenAICoachProvider,
+)
+
+FALLBACK_TEXT = (
+    "Coach feedback is taking longer than expected. Please try again in a moment."
+)
+
+
+def _provider_from_env() -> CoachProvider:
+    name = os.getenv("COACH_PROVIDER", "openai").strip().lower()
+    if name == "mock":
+        return MockCoachProvider()
+    return OpenAICoachProvider()
+
+
+def generate_feedback(
+    metrics: Mapping[str, Any] | None,
+    *,
+    provider: CoachProvider | None = None,
+) -> dict[str, Any]:
+    metrics_dict = dict(metrics or {})
+    active_provider = provider or _provider_from_env()
+    start = time.perf_counter()
+    try:
+        text = active_provider.generate(metrics_dict)
+        provider_name = getattr(
+            active_provider, "name", active_provider.__class__.__name__
+        )
+        latency = int((time.perf_counter() - start) * 1000)
+        return {"text": text, "provider": provider_name, "latency_ms": latency}
+    except (CoachProviderTimeout, httpx.TimeoutException, TimeoutError):
+        latency = int((time.perf_counter() - start) * 1000)
+        return {"text": FALLBACK_TEXT, "provider": "fallback", "latency_ms": latency}
+    except CoachProviderError:
+        latency = int((time.perf_counter() - start) * 1000)
+        return {"text": FALLBACK_TEXT, "provider": "fallback", "latency_ms": latency}

--- a/server/tests/test_coach_feedback_router.py
+++ b/server/tests/test_coach_feedback_router.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+from starlette.requests import Request
+
+from server.api.routers import coach_feedback
+
+
+app = FastAPI()
+app.include_router(coach_feedback.router)
+
+
+def make_client() -> TestClient:
+    return TestClient(app)
+
+
+def setup_function() -> None:
+    with coach_feedback._rate_lock:  # type: ignore[attr-defined]
+        coach_feedback._rate_buckets.clear()  # type: ignore[attr-defined]
+
+
+def test_request_requires_identifier() -> None:
+    with make_client() as client:
+        resp = client.post("/coach/feedback", json={})
+        assert resp.status_code == 422
+
+
+def test_run_id_not_found_returns_404(monkeypatch) -> None:
+    monkeypatch.setattr(coach_feedback, "load_run", lambda run_id: None)
+
+    with make_client() as client:
+        resp = client.post("/coach/feedback", json={"run_id": "1234567890-abcd1234"})
+        assert resp.status_code == 404
+
+
+def test_camel_case_run_id_supported(monkeypatch) -> None:
+    class Run:
+        metrics = {"ballSpeedMps": 62}
+
+    monkeypatch.setattr(coach_feedback, "load_run", lambda run_id: Run())
+    monkeypatch.setattr(
+        coach_feedback,
+        "generate_feedback",
+        lambda metrics: {"text": "ok", "provider": "mock", "latency_ms": 5},
+    )
+
+    with make_client() as client:
+        resp = client.post(
+            "/coach/feedback",
+            json={"runId": "1234567890-abcd1234", "metrics": {"carryEstM": 140}},
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == {"text": "ok", "provider": "mock", "latency_ms": 5}
+
+
+def test_metrics_list_rejected_by_validation(monkeypatch) -> None:
+    class Run:
+        metrics = {"ballSpeedMps": 60}
+
+    monkeypatch.setattr(coach_feedback, "load_run", lambda run_id: Run())
+    monkeypatch.setattr(
+        coach_feedback,
+        "generate_feedback",
+        lambda metrics: {"text": "ok", "provider": "mock", "latency_ms": 1},
+    )
+
+    with make_client() as client:
+        resp = client.post(
+            "/coach/feedback",
+            json={"run_id": "1234567890-abcd1234", "metrics": []},
+        )
+        assert resp.status_code == 422
+
+
+@pytest.mark.anyio
+async def test_handler_raises_400_for_non_dict_metrics(monkeypatch) -> None:
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/coach/feedback",
+        "headers": [],
+        "client": ("127.0.0.1", 12345),
+    }
+    request = Request(scope)
+    body = coach_feedback.CoachFeedbackRequest.model_construct(metrics="bad")
+
+    monkeypatch.setattr(coach_feedback, "load_run", lambda run_id: None)
+    monkeypatch.setattr(
+        coach_feedback,
+        "generate_feedback",
+        lambda metrics: {"text": "ok", "provider": "mock", "latency_ms": 1},
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await coach_feedback.coach_feedback(request, body)
+
+    assert exc.value.status_code == 400
+
+
+def test_successful_request_merges_metrics(monkeypatch) -> None:
+    class Run:
+        metrics = {"ballSpeedMps": 60, "quality": {"tempo": "stable"}}
+
+    monkeypatch.setattr(coach_feedback, "load_run", lambda run_id: Run())
+
+    captured = {}
+
+    def fake_generate(metrics):
+        captured.update(metrics)
+        return {"text": "ok", "provider": "mock", "latency_ms": 10}
+
+    monkeypatch.setattr(coach_feedback, "generate_feedback", fake_generate)
+
+    with make_client() as client:
+        resp = client.post(
+            "/coach/feedback",
+            json={"run_id": "1234567890-abcd1234", "metrics": {"carryEstM": 150}},
+        )
+        assert resp.status_code == 200, resp.text
+        assert captured == {
+            "ballSpeedMps": 60,
+            "quality": {"tempo": "stable"},
+            "carryEstM": 150,
+        }
+        assert resp.json() == {"text": "ok", "provider": "mock", "latency_ms": 10}
+
+
+def test_rate_limit_returns_429(monkeypatch) -> None:
+    monkeypatch.setattr(
+        coach_feedback,
+        "generate_feedback",
+        lambda metrics: {"text": "ok", "provider": "mock", "latency_ms": 1},
+    )
+
+    with make_client() as client:
+        for _ in range(coach_feedback._RATE_LIMIT_MAX_REQUESTS):  # type: ignore[attr-defined]
+            resp = client.post(
+                "/coach/feedback",
+                json={"metrics": {"ballSpeedMps": 50}},
+            )
+            assert resp.status_code == 200
+
+        resp = client.post(
+            "/coach/feedback",
+            json={"metrics": {"ballSpeedMps": 55}},
+        )
+        assert resp.status_code == 429

--- a/server/tests/test_coach_provider_mock.py
+++ b/server/tests/test_coach_provider_mock.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from server.services.coach import FALLBACK_TEXT, generate_feedback
+from server.services.coach.providers import (
+    CoachProviderError,
+    CoachProviderTimeout,
+    MockCoachProvider,
+    OpenAICoachProvider,
+)
+from server.services.coach.service import _provider_from_env
+
+
+def test_mock_provider_returns_deterministic_text() -> None:
+    provider = MockCoachProvider()
+    first = provider.generate({"ballSpeedMps": 60})
+    second = provider.generate({"ballSpeedMps": 45})
+    assert first == second
+    assert "tempo" in first.lower()
+
+
+class TimeoutProvider(MockCoachProvider):
+    name = "timeout"
+
+    def generate(self, metrics):  # type: ignore[override]
+        raise CoachProviderTimeout("timeout")
+
+
+def test_timeout_falls_back_to_placeholder() -> None:
+    result = generate_feedback({}, provider=TimeoutProvider())
+    assert result["text"] == FALLBACK_TEXT
+    assert result["provider"] == "fallback"
+    assert result["latency_ms"] >= 0
+
+
+class EchoProvider(MockCoachProvider):
+    name = "echo"
+
+    def generate(self, metrics):  # type: ignore[override]
+        assert metrics == {"value": 1}
+        return "All good"
+
+
+def test_generate_feedback_returns_provider_result() -> None:
+    result = generate_feedback({"value": 1}, provider=EchoProvider())
+    assert result["text"] == "All good"
+    assert result["provider"] == "echo"
+    assert result["latency_ms"] >= 0
+
+
+class ErrorProvider(MockCoachProvider):
+    name = "error"
+
+    def generate(self, metrics):  # type: ignore[override]
+        raise CoachProviderError("boom")
+
+
+def test_generate_feedback_handles_provider_error() -> None:
+    result = generate_feedback({"value": 2}, provider=ErrorProvider())
+    assert result["text"] == FALLBACK_TEXT
+    assert result["provider"] == "fallback"
+    assert result["latency_ms"] >= 0
+
+
+def test_provider_from_env_selects_mock(monkeypatch) -> None:
+    monkeypatch.setenv("COACH_PROVIDER", "mock")
+    provider = _provider_from_env()
+    assert isinstance(provider, MockCoachProvider)
+
+
+def test_provider_from_env_defaults_to_openai(monkeypatch) -> None:
+    monkeypatch.delenv("COACH_PROVIDER", raising=False)
+    provider = _provider_from_env()
+    assert isinstance(provider, OpenAICoachProvider)

--- a/server/tests/test_coach_provider_openai.py
+++ b/server/tests/test_coach_provider_openai.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from server.services.coach.providers import (
+    CoachProviderError,
+    CoachProviderTimeout,
+    OpenAICoachProvider,
+)
+
+
+def build_provider(response: httpx.Response) -> OpenAICoachProvider:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return response
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.Client(base_url="https://api.openai.com/v1", transport=transport)
+    return OpenAICoachProvider(api_key="test", http_client=client, timeout=1.0)
+
+
+def test_generate_uses_tool_call_feedback() -> None:
+    feedback_text = "Great tempo."
+    payload = {
+        "choices": [
+            {
+                "message": {
+                    "tool_calls": [
+                        {
+                            "function": {
+                                "name": "analyze_swing",
+                                "arguments": json.dumps({"feedback": feedback_text}),
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+
+    provider = build_provider(httpx.Response(200, json=payload))
+
+    assert provider.generate({"ballSpeedMps": 60}) == feedback_text
+
+
+def test_generate_falls_back_to_message_content() -> None:
+    payload = {
+        "choices": [
+            {
+                "message": {
+                    "content": "Fallback content",
+                }
+            }
+        ]
+    }
+    provider = build_provider(httpx.Response(200, json=payload))
+
+    assert provider.generate({}) == "Fallback content"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {"choices": []},
+        {"choices": [{"message": {"tool_calls": [{}]}}]},
+        {
+            "choices": [
+                {
+                    "message": {
+                        "tool_calls": [
+                            {
+                                "function": {
+                                    "name": "analyze_swing",
+                                    "arguments": "not json",
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+    ],
+)
+def test_generate_raises_for_invalid_payload(payload: dict[str, Any]) -> None:
+    provider = build_provider(httpx.Response(200, json=payload))
+    with pytest.raises(CoachProviderError):
+        provider.generate({})
+
+
+def test_post_translates_timeout_to_provider_timeout() -> None:
+    class TimeoutClient:
+        def post(self, *_args: Any, **_kwargs: Any) -> httpx.Response:
+            raise httpx.TimeoutException("timeout")
+
+    provider = OpenAICoachProvider(
+        api_key="test", http_client=TimeoutClient(), timeout=0.1
+    )
+
+    with pytest.raises(CoachProviderTimeout):
+        provider.generate({})
+
+
+def test_generate_requires_api_key() -> None:
+    with httpx.Client(base_url="https://api.openai.com/v1") as client:
+        provider = OpenAICoachProvider(api_key="", http_client=client)
+        with pytest.raises(CoachProviderError):
+            provider.generate({})
+
+
+def test_generate_uses_global_httpx_post(monkeypatch) -> None:
+    called: dict[str, Any] = {}
+
+    def fake_post(
+        url: str, json: Any, headers: dict[str, str], timeout: float
+    ) -> httpx.Response:
+        called["url"] = url
+        called["headers"] = headers
+        return httpx.Response(
+            200,
+            json={"choices": [{"message": {"content": "Hi"}}]},
+            request=httpx.Request("POST", url),
+        )
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+    provider = OpenAICoachProvider(api_key="test", http_client=None, timeout=0.1)
+
+    assert provider.generate({}) == "Hi"
+    assert called["url"] == "https://api.openai.com/v1/chat/completions"
+    assert called["headers"]["Authorization"] == "Bearer test"
+
+
+def test_post_translates_http_error() -> None:
+    class ErrorClient:
+        def post(self, *_args: Any, **_kwargs: Any) -> httpx.Response:
+            raise httpx.HTTPError("failure")
+
+    provider = OpenAICoachProvider(
+        api_key="test", http_client=ErrorClient(), timeout=0.1
+    )
+
+    with pytest.raises(CoachProviderError):
+        provider.generate({})
+
+
+def test_generate_raises_on_http_status_error() -> None:
+    response = httpx.Response(
+        401,
+        json={"error": "bad key"},
+        request=httpx.Request("POST", "https://api.openai.com/v1/chat/completions"),
+    )
+    provider = build_provider(response)
+
+    with pytest.raises(CoachProviderError):
+        provider.generate({})
+
+
+def test_generate_raises_when_no_feedback_present() -> None:
+    payload = {
+        "choices": [
+            {
+                "message": {
+                    "tool_calls": [
+                        {
+                            "function": {
+                                "name": "analyze_swing",
+                                "arguments": json.dumps({"feedback": "   "}),
+                            }
+                        }
+                    ],
+                    "content": "   ",
+                }
+            }
+        ]
+    }
+    provider = build_provider(httpx.Response(200, json=payload))
+
+    with pytest.raises(CoachProviderError):
+        provider.generate({})


### PR DESCRIPTION
Recreates Coach v1 server on top of current main.
- Provider abstraction + OpenAI provider
- Router POST /coach/feedback
- Request model accepts both runId and run_id
- Docs & tests updated

Supersedes #126.