### PR TITLE
feat(demo): add Demo Mode (offline wow) with deterministic sample runs + UI payloads

### DIFF
--- a/cv_engine/tests/test_demo_mode.py
+++ b/cv_engine/tests/test_demo_mode.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from scripts import run_demo
+
+
+def test_demo_case_verify_ready(tmp_path: Path) -> None:
+    out_path = tmp_path / "ready.json"
+    metrics = run_demo.run_demo_case("ready", out_path=out_path, verify=True)
+
+    assert "explain_result" in metrics
+    assert "micro_coach" in metrics
+
+    tips = metrics["micro_coach"]["tips"]
+    assert len(tips) <= 3
+
+    golden = run_demo.load_golden("ready")
+    assert [tip["id"] for tip in tips] == [
+        tip["id"] for tip in golden["micro_coach"]["tips"]
+    ]

--- a/demo_assets/README.md
+++ b/demo_assets/README.md
@@ -1,0 +1,24 @@
+# Demo Assets
+
+This folder contains small, deterministic inputs used by `scripts/run_demo.py` to showcase
+GolfIQ's offline Demo Mode.
+
+## Structure
+- `cases/`: JSON case definitions that describe synthetic frame bundles.
+- `golden/`: Expected metrics payloads for each case, used by `--verify`.
+
+## Case definitions
+Each case JSON defines the synthetic capture bundle:
+
+- `case_id`: Unique identifier for the demo case.
+- `description`: Short description of the scenario.
+- `fps`: Frames per second for the capture (used for Range Mode guardrails).
+- `frame_count`: Number of frames to generate.
+- `width` / `height`: Frame dimensions in pixels.
+- `pattern`: Frame generator configuration.
+  - `type`: `checkerboard` or `solid`.
+  - `low` / `high`: Checkerboard intensity values (0-255).
+  - `value`: Solid intensity value (0-255).
+
+The generator produces small RGB frames (uint8) so the pipeline can run without any
+external video files or ML models.

--- a/demo_assets/cases/block.json
+++ b/demo_assets/cases/block.json
@@ -1,0 +1,12 @@
+{
+  "case_id": "block",
+  "description": "Very low FPS with dark, blurry frames to trigger a block state.",
+  "fps": 30,
+  "frame_count": 12,
+  "width": 64,
+  "height": 64,
+  "pattern": {
+    "type": "solid",
+    "value": 20
+  }
+}

--- a/demo_assets/cases/ready.json
+++ b/demo_assets/cases/ready.json
@@ -1,0 +1,13 @@
+{
+  "case_id": "ready",
+  "description": "High-quality capture with stable lighting and sharp frames.",
+  "fps": 240,
+  "frame_count": 12,
+  "width": 64,
+  "height": 64,
+  "pattern": {
+    "type": "checkerboard",
+    "low": 80,
+    "high": 160
+  }
+}

--- a/demo_assets/cases/warn.json
+++ b/demo_assets/cases/warn.json
@@ -1,0 +1,13 @@
+{
+  "case_id": "warn",
+  "description": "Low-FPS capture with dark lighting but sharp frames.",
+  "fps": 60,
+  "frame_count": 12,
+  "width": 64,
+  "height": 64,
+  "pattern": {
+    "type": "checkerboard",
+    "low": 0,
+    "high": 100
+  }
+}

--- a/demo_assets/golden/block.json
+++ b/demo_assets/golden/block.json
@@ -1,0 +1,343 @@
+{
+  "ballSpeedMps": 1.829,
+  "ball_speed_mph": 4.1,
+  "ball_speed_mps": 1.83,
+  "calibration_v1": {
+    "fit": {
+      "apex_m_est": null,
+      "azimuth_deg": 0.0,
+      "carry_m_est": null,
+      "fit_metric": "r2",
+      "fit_r2": 1.0,
+      "fit_rmse": 2.383707702181096e-17,
+      "launch_angle_deg": 26.565051177077983,
+      "n_fit_points": 12,
+      "r2_or_residual": 1.0
+    },
+    "launch_window": {
+      "end_frame": 11,
+      "n_points": 12,
+      "start_frame": 0
+    },
+    "quality": {
+      "confidence_score_0_1": 0.65,
+      "reasons": [
+        "fallback_scale"
+      ]
+    },
+    "status": "low_confidence",
+    "used_m_per_px": 0.0025
+  },
+  "capture_quality": {
+    "issues": [
+      {
+        "code": "LOW_FPS",
+        "details": {
+          "fps": 30.0,
+          "recommended": 120.0,
+          "warn_threshold": 60.0
+        },
+        "message": "Frame rate is too low for reliable tracking.",
+        "severity": "warn"
+      },
+      {
+        "code": "LOW_RESOLUTION",
+        "details": {
+          "height": 64,
+          "min_height": 720,
+          "recommended_height": 1080
+        },
+        "message": "Resolution is below the recommended minimum.",
+        "severity": "warn"
+      },
+      {
+        "code": "UNDEREXPOSED",
+        "details": {
+          "luma_threshold": 60.0,
+          "threshold": 0.3,
+          "underexposed_pct": 1.0
+        },
+        "message": "Video appears too dark for reliable tracking.",
+        "severity": "warn"
+      },
+      {
+        "code": "MOTION_BLUR",
+        "details": {
+          "blur_variance_mean": 0.0,
+          "blurry_pct": 1.0,
+          "laplacian_var_threshold": 200.0,
+          "threshold": 0.3
+        },
+        "message": "Video appears blurry; use a faster shutter or stabilize.",
+        "severity": "warn"
+      }
+    ],
+    "range_mode": {
+      "diagnostics": {
+        "brightness_bright_pct": 0.0,
+        "brightness_dark_pct": 1.0,
+        "brightness_mean": 20.0,
+        "effective_fps": 30.0,
+        "sharpness_blur_pct": 1.0,
+        "sharpness_mean": 0.0,
+        "track_edge_pct": 0.0,
+        "track_length": 12
+      },
+      "flags": [
+        "fps_low",
+        "exposure_too_dark",
+        "blur_high"
+      ],
+      "recommendations": [
+        "Record in slow-motion mode (120+ FPS minimum, 240 FPS ideal).",
+        "Increase lighting or move to a brighter area.",
+        "Use faster shutter/lock exposure and stabilize the phone."
+      ],
+      "score": 0.45
+    },
+    "range_mode_hud": {
+      "badges": [
+        "FPS",
+        "BLUR"
+      ],
+      "debug": {
+        "apply_hysteresis": false,
+        "flags": [
+          "fps_low",
+          "exposure_too_dark",
+          "blur_high"
+        ],
+        "hysteresis": {
+          "above_ready_count": 0,
+          "below_block_count": 0,
+          "state": "block"
+        },
+        "raw_state": "block",
+        "score_0_100": 45,
+        "single_eval": true
+      },
+      "primary_message": "Low frame rate",
+      "recommended_actions": [
+        "Switch to slow-mo (120\u2013240 FPS).",
+        "Stabilize the phone or use faster shutter."
+      ],
+      "score_0_100": 45,
+      "secondary_message": "Too much motion blur",
+      "state": "block"
+    },
+    "recommendations": [
+      "Enable slow-motion mode or increase capture FPS (120+ recommended).",
+      "Increase capture resolution (1080p+ recommended).",
+      "Improve lighting or move to a brighter area.",
+      "Use a faster shutter or stabilize the camera to reduce blur."
+    ],
+    "score": 40,
+    "summary": {
+      "blur_variance_mean": 0.0,
+      "blurry_pct": 1.0,
+      "fps": 30.0,
+      "frames": 12,
+      "overexposed_pct": 0.0,
+      "resolution": {
+        "height": 64,
+        "width": 64
+      },
+      "shake_diff_mean": 0.0,
+      "shaky_pct": 0.0,
+      "underexposed_pct": 1.0
+    }
+  },
+  "carryEstM": 0.02,
+  "carry_m": 0.0,
+  "clubSpeedMps": 0.043,
+  "club_path_deg": null,
+  "club_speed_mph": 0.1,
+  "club_speed_mps": 0.04,
+  "confidence": 0.0,
+  "explain": {
+    "confidence": 0.75,
+    "issues": [
+      {
+        "code": "fps_low",
+        "details": {
+          "error_below": 45.0,
+          "fps": 30.0
+        },
+        "message": "Capture FPS is below the recommended minimum.",
+        "severity": "error"
+      }
+    ],
+    "summary": "Confidence reduced: Capture FPS is below the recommended minimum."
+  },
+  "explain_result": {
+    "confidence": {
+      "label": "LOW",
+      "score": 0
+    },
+    "debug": {
+      "inputs_present": {
+        "calibration": true,
+        "guardrails": true,
+        "range_mode_hud": true
+      },
+      "signals_used": [
+        "fps_low",
+        "blur_high",
+        "exposure_too_dark"
+      ]
+    },
+    "version": "v1",
+    "what_to_do_now": [
+      {
+        "detail": "Enable slow-mo capture (120\u2013240 FPS).",
+        "id": "increase_fps",
+        "title": "Increase frame rate"
+      },
+      {
+        "detail": "Stabilize the phone or use faster shutter.",
+        "id": "reduce_blur",
+        "title": "Reduce blur"
+      },
+      {
+        "detail": "Brighten the hitting area and ball.",
+        "id": "improve_lighting",
+        "title": "Add lighting"
+      }
+    ],
+    "why_may_be_wrong": [
+      {
+        "detail": "Low FPS can miss the ball after impact.",
+        "id": "fps_low",
+        "title": "Low frame rate"
+      },
+      {
+        "detail": "Motion blur hides the ball in flight.",
+        "id": "blur_high",
+        "title": "Too much blur"
+      },
+      {
+        "detail": "The ball blends into a dark background.",
+        "id": "exposure_too_dark",
+        "title": "Too dark"
+      }
+    ]
+  },
+  "faceon": {
+    "frame": {
+      "h": 64,
+      "w": 64
+    },
+    "notes": "no-person-detected",
+    "shaft_lean_deg": 0.0,
+    "shoulder_tilt_deg": 0.0,
+    "sway_cm": 0.0,
+    "sway_px": 0.0
+  },
+  "inference": {
+    "avgInferenceMs": 0.0,
+    "frames": 12,
+    "modelVariant": "yolov10",
+    "totalInferenceMs": 0.0
+  },
+  "launch_deg": 88.1,
+  "metrics_version": 1,
+  "micro_coach": {
+    "debug": {
+      "deduped_tip_ids": [
+        "tip_fps_light",
+        "tip_stabilize_phone",
+        "tip_even_lighting"
+      ],
+      "inputs_present": {
+        "calibration": true,
+        "explain_result": true,
+        "range_mode_hud": true
+      },
+      "selected_rule_ids": [
+        "tip_fps_light",
+        "tip_stabilize_phone",
+        "tip_even_lighting"
+      ]
+    },
+    "enabled": true,
+    "tips": [
+      {
+        "detail": "\u00d6ka belysningen s\u00e5 kameran kan k\u00f6ra snabbare bildhastighet.",
+        "id": "tip_fps_light",
+        "priority": 1,
+        "source": {
+          "action_ids": [
+            "increase_fps"
+          ],
+          "confidence_label": "LOW",
+          "hud_flags": [
+            "fps_low"
+          ],
+          "reason_ids": [
+            "fps_low"
+          ]
+        },
+        "title": "Mer ljus f\u00f6r h\u00f6gre FPS"
+      },
+      {
+        "detail": "St\u00f6d mobilen och undvik panorering s\u00e5 bollen blir skarp.",
+        "id": "tip_stabilize_phone",
+        "priority": 1,
+        "source": {
+          "action_ids": [
+            "reduce_blur"
+          ],
+          "confidence_label": "LOW",
+          "hud_flags": [
+            "blur_high"
+          ],
+          "reason_ids": [
+            "blur_high"
+          ]
+        },
+        "title": "Stabilisera kameran"
+      },
+      {
+        "detail": "Flytta till j\u00e4mnare ljus s\u00e5 bollen syns tydligt.",
+        "id": "tip_even_lighting",
+        "priority": 2,
+        "source": {
+          "action_ids": [
+            "improve_lighting"
+          ],
+          "confidence_label": "LOW",
+          "hud_flags": [
+            "exposure_too_dark"
+          ],
+          "reason_ids": [
+            "exposure_too_dark"
+          ]
+        },
+        "title": "J\u00e4mnare ljus"
+      }
+    ],
+    "version": "v1"
+  },
+  "quality": {
+    "fps": "low",
+    "homography": "warn",
+    "lighting": "low"
+  },
+  "sideAngleDeg": 90.0,
+  "spin_axis_deg": null,
+  "spin_rpm": null,
+  "tracking": {
+    "filled_frames": 0,
+    "gap_ratio": 0.0,
+    "id_switches": 0,
+    "jitter_px": 0.0,
+    "max_gap": 0,
+    "n_detections": 12,
+    "n_frames": 12,
+    "n_missing": 0,
+    "outliers_removed": 0,
+    "segments_linked": 0,
+    "stabilized": true
+  },
+  "vertLaunchDeg": 0.0
+}

--- a/demo_assets/golden/ready.json
+++ b/demo_assets/golden/ready.json
@@ -1,0 +1,217 @@
+{
+  "ballSpeedMps": 0.668,
+  "ball_speed_mph": 1.5,
+  "ball_speed_mps": 0.67,
+  "calibration_v1": {
+    "fit": {
+      "apex_m_est": null,
+      "azimuth_deg": 0.0,
+      "carry_m_est": null,
+      "fit_metric": "r2",
+      "fit_r2": 1.0,
+      "fit_rmse": 2.6040805070549545e-16,
+      "launch_angle_deg": 26.56505117707779,
+      "n_fit_points": 12,
+      "r2_or_residual": 1.0
+    },
+    "launch_window": {
+      "end_frame": 11,
+      "n_points": 12,
+      "start_frame": 0
+    },
+    "quality": {
+      "confidence_score_0_1": 0.65,
+      "reasons": [
+        "fallback_scale"
+      ]
+    },
+    "status": "low_confidence",
+    "used_m_per_px": 0.0025
+  },
+  "capture_quality": {
+    "issues": [
+      {
+        "code": "LOW_RESOLUTION",
+        "details": {
+          "height": 64,
+          "min_height": 720,
+          "recommended_height": 1080
+        },
+        "message": "Resolution is below the recommended minimum.",
+        "severity": "warn"
+      }
+    ],
+    "range_mode": {
+      "diagnostics": {
+        "brightness_bright_pct": 0.0,
+        "brightness_dark_pct": 0.0,
+        "brightness_mean": 120.0,
+        "effective_fps": 240.0,
+        "sharpness_blur_pct": 0.0,
+        "sharpness_mean": 99612.5,
+        "track_edge_pct": 0.0,
+        "track_length": 12
+      },
+      "flags": [],
+      "recommendations": [],
+      "score": 1.0
+    },
+    "range_mode_hud": {
+      "badges": [],
+      "debug": {
+        "apply_hysteresis": false,
+        "flags": [],
+        "hysteresis": {
+          "above_ready_count": 0,
+          "below_block_count": 0,
+          "state": "ready"
+        },
+        "raw_state": "ready",
+        "score_0_100": 100,
+        "single_eval": true
+      },
+      "primary_message": "Capture looks good",
+      "recommended_actions": [],
+      "score_0_100": 100,
+      "secondary_message": null,
+      "state": "ready"
+    },
+    "recommendations": [
+      "Increase capture resolution (1080p+ recommended)."
+    ],
+    "score": 85,
+    "summary": {
+      "blur_variance_mean": 99612.5,
+      "blurry_pct": 0.0,
+      "fps": 240.0,
+      "frames": 12,
+      "overexposed_pct": 0.0,
+      "resolution": {
+        "height": 64,
+        "width": 64
+      },
+      "shake_diff_mean": 0.0,
+      "shaky_pct": 0.0,
+      "underexposed_pct": 0.0
+    }
+  },
+  "carryEstM": 0.04,
+  "carry_m": 0.0,
+  "clubSpeedMps": 0.345,
+  "club_path_deg": null,
+  "club_speed_mph": 0.8,
+  "club_speed_mps": 0.35,
+  "confidence": 0.0,
+  "explain": {
+    "confidence": 1.0,
+    "issues": [],
+    "summary": "No issues detected."
+  },
+  "explain_result": {
+    "confidence": {
+      "label": "HIGH",
+      "score": 75
+    },
+    "debug": {
+      "inputs_present": {
+        "calibration": true,
+        "guardrails": true,
+        "range_mode_hud": true
+      },
+      "signals_used": [
+        "calibration_low_confidence"
+      ]
+    },
+    "version": "v1",
+    "what_to_do_now": [
+      {
+        "detail": "Re-run calibration with clearer tracking.",
+        "id": "recalibrate_scale",
+        "title": "Recalibrate scale"
+      }
+    ],
+    "why_may_be_wrong": [
+      {
+        "detail": "Metric fit confidence is below target.",
+        "id": "calibration_low_confidence",
+        "title": "Calibration confidence low"
+      }
+    ]
+  },
+  "faceon": {
+    "frame": {
+      "h": 64,
+      "w": 64
+    },
+    "notes": "no-person-detected",
+    "shaft_lean_deg": 0.0,
+    "shoulder_tilt_deg": 0.0,
+    "sway_cm": 0.0,
+    "sway_px": 0.0
+  },
+  "inference": {
+    "avgInferenceMs": 0.0,
+    "frames": 12,
+    "modelVariant": "yolov10",
+    "totalInferenceMs": 0.0
+  },
+  "launch_deg": 44.1,
+  "metrics_version": 1,
+  "micro_coach": {
+    "debug": {
+      "deduped_tip_ids": [
+        "tip_redo_calibration"
+      ],
+      "inputs_present": {
+        "calibration": true,
+        "explain_result": true,
+        "range_mode_hud": true
+      },
+      "selected_rule_ids": [
+        "tip_redo_calibration"
+      ]
+    },
+    "enabled": true,
+    "tips": [
+      {
+        "detail": "Anv\u00e4nd tydliga mark\u00f6rer och r\u00e4tt avst\u00e5nd n\u00e4r du kalibrerar.",
+        "id": "tip_redo_calibration",
+        "priority": 3,
+        "source": {
+          "action_ids": [
+            "recalibrate_scale"
+          ],
+          "confidence_label": "HIGH",
+          "hud_flags": [],
+          "reason_ids": [
+            "calibration_low_confidence"
+          ]
+        },
+        "title": "G\u00f6r om kalibreringen"
+      }
+    ],
+    "version": "v1"
+  },
+  "quality": {
+    "fps": "good",
+    "homography": "warn",
+    "lighting": "good"
+  },
+  "sideAngleDeg": 90.0,
+  "spin_axis_deg": null,
+  "spin_rpm": null,
+  "tracking": {
+    "filled_frames": 0,
+    "gap_ratio": 0.0,
+    "id_switches": 0,
+    "jitter_px": 0.0,
+    "max_gap": 0,
+    "n_detections": 12,
+    "n_frames": 12,
+    "n_missing": 0,
+    "outliers_removed": 0,
+    "segments_linked": 0,
+    "stabilized": true
+  },
+  "vertLaunchDeg": 0.0
+}

--- a/demo_assets/golden/warn.json
+++ b/demo_assets/golden/warn.json
@@ -1,0 +1,305 @@
+{
+  "ballSpeedMps": 0.967,
+  "ball_speed_mph": 2.2,
+  "ball_speed_mps": 0.97,
+  "calibration_v1": {
+    "fit": {
+      "apex_m_est": null,
+      "azimuth_deg": 0.0,
+      "carry_m_est": null,
+      "fit_metric": "r2",
+      "fit_r2": 1.0,
+      "fit_rmse": 7.078101895173003e-18,
+      "launch_angle_deg": 26.565051177077986,
+      "n_fit_points": 12,
+      "r2_or_residual": 1.0
+    },
+    "launch_window": {
+      "end_frame": 11,
+      "n_points": 12,
+      "start_frame": 0
+    },
+    "quality": {
+      "confidence_score_0_1": 0.65,
+      "reasons": [
+        "fallback_scale"
+      ]
+    },
+    "status": "low_confidence",
+    "used_m_per_px": 0.0025
+  },
+  "capture_quality": {
+    "issues": [
+      {
+        "code": "LOW_RESOLUTION",
+        "details": {
+          "height": 64,
+          "min_height": 720,
+          "recommended_height": 1080
+        },
+        "message": "Resolution is below the recommended minimum.",
+        "severity": "warn"
+      },
+      {
+        "code": "UNDEREXPOSED",
+        "details": {
+          "luma_threshold": 60.0,
+          "threshold": 0.3,
+          "underexposed_pct": 1.0
+        },
+        "message": "Video appears too dark for reliable tracking.",
+        "severity": "warn"
+      }
+    ],
+    "range_mode": {
+      "diagnostics": {
+        "brightness_bright_pct": 0.0,
+        "brightness_dark_pct": 1.0,
+        "brightness_mean": 50.0,
+        "effective_fps": 60.0,
+        "sharpness_blur_pct": 0.0,
+        "sharpness_mean": 155644.516,
+        "track_edge_pct": 0.0,
+        "track_length": 12
+      },
+      "flags": [
+        "fps_low",
+        "exposure_too_dark"
+      ],
+      "recommendations": [
+        "Record in slow-motion mode (120+ FPS minimum, 240 FPS ideal).",
+        "Increase lighting or move to a brighter area."
+      ],
+      "score": 0.65
+    },
+    "range_mode_hud": {
+      "badges": [
+        "FPS",
+        "LIGHT"
+      ],
+      "debug": {
+        "apply_hysteresis": false,
+        "flags": [
+          "fps_low",
+          "exposure_too_dark"
+        ],
+        "hysteresis": {
+          "above_ready_count": 0,
+          "below_block_count": 0,
+          "state": "warn"
+        },
+        "raw_state": "warn",
+        "score_0_100": 65,
+        "single_eval": true
+      },
+      "primary_message": "Low frame rate",
+      "recommended_actions": [
+        "Switch to slow-mo (120\u2013240 FPS).",
+        "Increase light on the hitting area."
+      ],
+      "score_0_100": 65,
+      "secondary_message": "Scene is too dark",
+      "state": "warn"
+    },
+    "recommendations": [
+      "Increase capture resolution (1080p+ recommended).",
+      "Improve lighting or move to a brighter area."
+    ],
+    "score": 70,
+    "summary": {
+      "blur_variance_mean": 155644.5312,
+      "blurry_pct": 0.0,
+      "fps": 60.0,
+      "frames": 12,
+      "overexposed_pct": 0.0,
+      "resolution": {
+        "height": 64,
+        "width": 64
+      },
+      "shake_diff_mean": 0.0,
+      "shaky_pct": 0.0,
+      "underexposed_pct": 1.0
+    }
+  },
+  "carryEstM": 0.02,
+  "carry_m": 0.0,
+  "clubSpeedMps": 0.086,
+  "club_path_deg": null,
+  "club_speed_mph": 0.2,
+  "club_speed_mps": 0.09,
+  "confidence": 0.0,
+  "explain": {
+    "confidence": 1.0,
+    "issues": [],
+    "summary": "No issues detected."
+  },
+  "explain_result": {
+    "confidence": {
+      "label": "LOW",
+      "score": 15
+    },
+    "debug": {
+      "inputs_present": {
+        "calibration": true,
+        "guardrails": true,
+        "range_mode_hud": true
+      },
+      "signals_used": [
+        "fps_low",
+        "exposure_too_dark",
+        "calibration_low_confidence"
+      ]
+    },
+    "version": "v1",
+    "what_to_do_now": [
+      {
+        "detail": "Enable slow-mo capture (120\u2013240 FPS).",
+        "id": "increase_fps",
+        "title": "Increase frame rate"
+      },
+      {
+        "detail": "Brighten the hitting area and ball.",
+        "id": "improve_lighting",
+        "title": "Add lighting"
+      },
+      {
+        "detail": "Re-run calibration with clearer tracking.",
+        "id": "recalibrate_scale",
+        "title": "Recalibrate scale"
+      }
+    ],
+    "why_may_be_wrong": [
+      {
+        "detail": "Low FPS can miss the ball after impact.",
+        "id": "fps_low",
+        "title": "Low frame rate"
+      },
+      {
+        "detail": "The ball blends into a dark background.",
+        "id": "exposure_too_dark",
+        "title": "Too dark"
+      },
+      {
+        "detail": "Metric fit confidence is below target.",
+        "id": "calibration_low_confidence",
+        "title": "Calibration confidence low"
+      }
+    ]
+  },
+  "faceon": {
+    "frame": {
+      "h": 64,
+      "w": 64
+    },
+    "notes": "no-person-detected",
+    "shaft_lean_deg": 0.0,
+    "shoulder_tilt_deg": 0.0,
+    "sway_cm": 0.0,
+    "sway_px": 0.0
+  },
+  "inference": {
+    "avgInferenceMs": 0.0,
+    "frames": 12,
+    "modelVariant": "yolov10",
+    "totalInferenceMs": 0.0
+  },
+  "launch_deg": 82.9,
+  "metrics_version": 1,
+  "micro_coach": {
+    "debug": {
+      "deduped_tip_ids": [
+        "tip_fps_light",
+        "tip_even_lighting",
+        "tip_redo_calibration"
+      ],
+      "inputs_present": {
+        "calibration": true,
+        "explain_result": true,
+        "range_mode_hud": true
+      },
+      "selected_rule_ids": [
+        "tip_fps_light",
+        "tip_even_lighting",
+        "tip_redo_calibration"
+      ]
+    },
+    "enabled": true,
+    "tips": [
+      {
+        "detail": "\u00d6ka belysningen s\u00e5 kameran kan k\u00f6ra snabbare bildhastighet.",
+        "id": "tip_fps_light",
+        "priority": 1,
+        "source": {
+          "action_ids": [
+            "increase_fps"
+          ],
+          "confidence_label": "LOW",
+          "hud_flags": [
+            "fps_low"
+          ],
+          "reason_ids": [
+            "fps_low"
+          ]
+        },
+        "title": "Mer ljus f\u00f6r h\u00f6gre FPS"
+      },
+      {
+        "detail": "Flytta till j\u00e4mnare ljus s\u00e5 bollen syns tydligt.",
+        "id": "tip_even_lighting",
+        "priority": 2,
+        "source": {
+          "action_ids": [
+            "improve_lighting"
+          ],
+          "confidence_label": "LOW",
+          "hud_flags": [
+            "exposure_too_dark"
+          ],
+          "reason_ids": [
+            "exposure_too_dark"
+          ]
+        },
+        "title": "J\u00e4mnare ljus"
+      },
+      {
+        "detail": "Anv\u00e4nd tydliga mark\u00f6rer och r\u00e4tt avst\u00e5nd n\u00e4r du kalibrerar.",
+        "id": "tip_redo_calibration",
+        "priority": 3,
+        "source": {
+          "action_ids": [
+            "recalibrate_scale"
+          ],
+          "confidence_label": "LOW",
+          "hud_flags": [],
+          "reason_ids": [
+            "calibration_low_confidence"
+          ]
+        },
+        "title": "G\u00f6r om kalibreringen"
+      }
+    ],
+    "version": "v1"
+  },
+  "quality": {
+    "fps": "warn",
+    "homography": "warn",
+    "lighting": "low"
+  },
+  "sideAngleDeg": 90.0,
+  "spin_axis_deg": null,
+  "spin_rpm": null,
+  "tracking": {
+    "filled_frames": 0,
+    "gap_ratio": 0.0,
+    "id_switches": 0,
+    "jitter_px": 0.0,
+    "max_gap": 0,
+    "n_detections": 12,
+    "n_frames": 12,
+    "n_missing": 0,
+    "outliers_removed": 0,
+    "segments_linked": 0,
+    "stabilized": true
+  },
+  "vertLaunchDeg": 0.0
+}

--- a/docs/demo_mode.md
+++ b/docs/demo_mode.md
@@ -1,0 +1,40 @@
+# Demo Mode (Offline)
+
+Demo Mode is a fully offline, deterministic showcase of GolfIQ's Range Mode analysis. It is
+built for product demos with golfers and investors and runs on a clean machine without
+network calls or new video capture.
+
+## What Demo Mode shows
+Each demo case produces a metrics payload that highlights:
+
+1. **Capture-quality HUD** (READY/WARN/BLOCK)
+2. **`explain_result`** confidence and guidance
+3. **`micro_coach` tips** (up to 3 actionable items)
+
+The story is consistent: _capture quality → confidence → concrete fixes_.
+
+## How to run
+```bash
+python scripts/run_demo.py --case ready
+python scripts/run_demo.py --case ready --verify
+python scripts/run_demo.py --case warn --out demo_out/warn.json
+```
+
+The output is written to `demo_out/<case_id>.json` by default.
+
+## What to look at in the output
+- `capture_quality.range_mode_hud.state` → READY/WARN/BLOCK
+- `explain_result.confidence.label` → HIGH/MED/LOW
+- `micro_coach.tips` → 1–3 prioritized fixes
+
+## Add a new demo case
+1. Add a JSON definition in `demo_assets/cases/<case_id>.json` describing the synthetic
+   frames (size, FPS, pattern).
+2. Run the demo to generate output:
+   ```bash
+   python scripts/run_demo.py --case <case_id>
+   ```
+3. Copy the generated output into `demo_assets/golden/<case_id>.json`.
+4. Update or add tests in `cv_engine/tests/test_demo_mode.py` if needed.
+
+Demo cases are intentionally small to keep the repository lightweight and deterministic.

--- a/scripts/run_demo.py
+++ b/scripts/run_demo.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from dataclasses import asdict, is_dataclass
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+import numpy as np
+
+from cv_engine.metrics.kinematics import CalibrationParams
+from cv_engine.pipeline.analyze import analyze_frames
+
+DEMO_ASSETS = REPO_ROOT / "demo_assets"
+CASE_DIR = DEMO_ASSETS / "cases"
+GOLDEN_DIR = DEMO_ASSETS / "golden"
+DEFAULT_OUT_DIR = REPO_ROOT / "demo_out"
+
+
+def load_case(case_id: str) -> dict[str, Any]:
+    path = CASE_DIR / f"{case_id}.json"
+    if not path.exists():
+        raise FileNotFoundError(f"Unknown demo case: {case_id}")
+    return json.loads(path.read_text())
+
+
+def load_golden(case_id: str) -> dict[str, Any]:
+    path = GOLDEN_DIR / f"{case_id}.json"
+    if not path.exists():
+        raise FileNotFoundError(f"Missing golden output for case: {case_id}")
+    return json.loads(path.read_text())
+
+
+def _build_frame(pattern: dict[str, Any], width: int, height: int) -> np.ndarray:
+    pattern_type = pattern.get("type")
+    if pattern_type == "checkerboard":
+        low = int(pattern.get("low", 0))
+        high = int(pattern.get("high", 255))
+        mask = (np.indices((height, width)).sum(axis=0) % 2).astype(np.uint8)
+        base = (mask * (high - low) + low).astype(np.uint8)
+    elif pattern_type == "solid":
+        value = int(pattern.get("value", 0))
+        base = np.full((height, width), value, dtype=np.uint8)
+    else:
+        raise ValueError(f"Unsupported pattern type: {pattern_type}")
+    return np.stack([base, base, base], axis=-1)
+
+
+def build_frames(case: dict[str, Any]) -> list[np.ndarray]:
+    width = int(case.get("width", 64))
+    height = int(case.get("height", 64))
+    frame_count = int(case.get("frame_count", 8))
+    pattern = case.get("pattern", {"type": "solid", "value": 0})
+    frame = _build_frame(pattern, width=width, height=height)
+    return [frame.copy() for _ in range(frame_count)]
+
+
+def _normalize_metrics(metrics: dict[str, Any]) -> dict[str, Any]:
+    normalized = json.loads(json.dumps(metrics))
+    inference = normalized.get("inference")
+    if isinstance(inference, dict):
+        inference["totalInferenceMs"] = 0.0
+        inference["avgInferenceMs"] = 0.0
+    return normalized
+
+
+def _coerce_dataclass(value: Any) -> Any:
+    if is_dataclass(value):
+        return asdict(value)
+    return value
+
+
+def _compare_values(
+    actual: Any,
+    expected: Any,
+    path: str,
+    *,
+    rel_tol: float = 1e-3,
+    abs_tol: float = 1e-3,
+) -> tuple[bool, str | None]:
+    actual = _coerce_dataclass(actual)
+    expected = _coerce_dataclass(expected)
+
+    if isinstance(expected, dict) and isinstance(actual, dict):
+        expected_keys = set(expected.keys())
+        actual_keys = set(actual.keys())
+        if expected_keys != actual_keys:
+            missing = sorted(expected_keys - actual_keys)
+            extra = sorted(actual_keys - expected_keys)
+            return (
+                False,
+                f"{path or 'root'} keys differ: missing={missing}, extra={extra}",
+            )
+        for key in sorted(expected_keys):
+            ok, message = _compare_values(
+                actual[key],
+                expected[key],
+                f"{path}.{key}" if path else key,
+                rel_tol=rel_tol,
+                abs_tol=abs_tol,
+            )
+            if not ok:
+                return ok, message
+        return True, None
+
+    if isinstance(expected, list) and isinstance(actual, list):
+        if len(actual) != len(expected):
+            return (
+                False,
+                f"{path or 'root'} length differs: {len(actual)} != {len(expected)}",
+            )
+        for idx, (act_item, exp_item) in enumerate(zip(actual, expected)):
+            ok, message = _compare_values(
+                act_item,
+                exp_item,
+                f"{path}[{idx}]" if path else f"[{idx}]",
+                rel_tol=rel_tol,
+                abs_tol=abs_tol,
+            )
+            if not ok:
+                return ok, message
+        return True, None
+
+    if isinstance(expected, (int, float)) and isinstance(actual, (int, float)):
+        if isinstance(expected, bool) or isinstance(actual, bool):
+            return (
+                expected == actual,
+                None if expected == actual else f"{path} bool differs",
+            )
+        if math.isclose(
+            float(actual), float(expected), rel_tol=rel_tol, abs_tol=abs_tol
+        ):
+            return True, None
+        return (
+            False,
+            f"{path or 'root'} differs: {actual} != {expected}",
+        )
+
+    if actual != expected:
+        return False, f"{path or 'root'} differs: {actual} != {expected}"
+
+    return True, None
+
+
+def verify_metrics(case_id: str, metrics: dict[str, Any]) -> None:
+    expected = load_golden(case_id)
+    ok, message = _compare_values(metrics, expected, "")
+    if not ok:
+        raise AssertionError(message)
+
+
+def summarize(metrics: dict[str, Any]) -> str:
+    hud = (
+        metrics.get("capture_quality", {}).get("range_mode_hud")
+        or metrics.get("range_mode_hud")
+        or {}
+    )
+    state = "unknown"
+    if isinstance(hud, dict):
+        state = str(hud.get("state", "unknown"))
+    confidence = (
+        metrics.get("explain_result", {}).get("confidence", {}).get("label", "unknown")
+    )
+    tips = metrics.get("micro_coach", {}).get("tips", [])
+    return f"HUD={state} confidence={confidence} tips={len(tips)}"
+
+
+def run_demo_case(
+    case_id: str,
+    *,
+    out_path: Path | None = None,
+    verify: bool = False,
+) -> dict[str, Any]:
+    case = load_case(case_id)
+    frames = build_frames(case)
+    calib = CalibrationParams(
+        m_per_px=float(case.get("m_per_px", 0.001)),
+        fps=float(case.get("fps", 240.0)),
+    )
+    result = analyze_frames(frames, calib, mock=True, smoothing_window=1)
+    metrics = _normalize_metrics(result["metrics"])
+
+    if out_path is None:
+        out_path = DEFAULT_OUT_DIR / f"{case_id}.json"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(metrics, indent=2, sort_keys=True))
+
+    if verify:
+        verify_metrics(case_id, metrics)
+
+    return metrics
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run offline demo cases.")
+    parser.add_argument("--case", dest="case_id", required=True)
+    parser.add_argument(
+        "--out",
+        dest="out",
+        default=None,
+        help="Output path (default: demo_out/<case_id>.json)",
+    )
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        help="Compare output to demo_assets/golden/<case_id>.json",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    out_path = Path(args.out) if args.out else None
+    try:
+        metrics = run_demo_case(args.case_id, out_path=out_path, verify=args.verify)
+    except (AssertionError, FileNotFoundError, ValueError) as exc:
+        print(f"Demo case failed: {exc}")
+        return 1
+
+    summary = summarize(metrics)
+    print(f"Demo case '{args.case_id}': {summary}")
+    if args.verify:
+        print(f"Verified against {GOLDEN_DIR / f'{args.case_id}.json'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_demo.py
+++ b/scripts/run_demo.py
@@ -16,6 +16,7 @@ DEMO_ASSETS = REPO_ROOT / "demo_assets"
 CASE_DIR = DEMO_ASSETS / "cases"
 GOLDEN_DIR = DEMO_ASSETS / "golden"
 DEFAULT_OUT_DIR = REPO_ROOT / "demo_out"
+DEMO_MODEL_VARIANT = "yolov10"
 
 _DEPS: tuple[object, object, object] | None = None
 
@@ -191,14 +192,22 @@ def run_demo_case(
     out_path: Path | None = None,
     verify: bool = False,
 ) -> dict[str, Any]:
-    np, CalibrationParams, analyze_frames = _load_pipeline_deps()
+    _, CalibrationParams, analyze_frames = _load_pipeline_deps()
     case = load_case(case_id)
     frames = build_frames(case)
     calib = CalibrationParams(
         m_per_px=float(case.get("m_per_px", 0.001)),
         fps=float(case.get("fps", 240.0)),
     )
-    result = analyze_frames(frames, calib, mock=True, smoothing_window=1)
+    # Demo Mode pins a mock-capable model variant to stay offline/deterministic
+    # regardless of MODEL_VARIANT environment settings.
+    result = analyze_frames(
+        frames,
+        calib,
+        mock=True,
+        smoothing_window=1,
+        model_variant=DEMO_MODEL_VARIANT,
+    )
     metrics = _normalize_metrics(result["metrics"])
 
     if out_path is None:


### PR DESCRIPTION
### Motivation
- Provide a fully offline, deterministic Demo Mode to showcase Range Mode HUD, `explain_result_v1`, and `micro_coach` tips without network or heavy ML dependencies.
- Make demos tiny, reproducible, and usable on a clean machine for product demos (golfers/investors).

### Description
- Add synthetic demo assets under `demo_assets/` including `cases/` JSON definitions and `golden/` expected metrics for `ready`, `warn`, and `block` scenarios.
- Implement `scripts/run_demo.py`, a CLI that builds synthetic frames, runs the existing `analyze_frames` pipeline with `mock=True`, writes a single JSON metrics file, prints a concise summary, and supports `--verify` to compare output against golden with a tolerant comparator.
- Add docs at `docs/demo_mode.md` describing purpose, how to run, what to inspect, and how to add cases.
- Add a fast test `cv_engine/tests/test_demo_mode.py` that runs the `ready` case in verify mode and asserts presence of `explain_result` and `micro_coach`, tip count <= 3, and deterministic tip ordering.

### Testing
- Ran the demo runner and generated goldens: `python scripts/run_demo.py --case ready|warn|block --out demo_assets/golden/<case>.json` which printed expected HUD/confidence/tips summaries and produced stable outputs.
- Verified demo output with `python scripts/run_demo.py --case ready --verify` which succeeded and printed verification confirmation.
- Ran formatter `python -m black .` successfully.
- Ran unit test `python -m pytest -q cv_engine/tests/test_demo_mode.py` which passed (1 passed in ~0.87s).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f3a2a8b6883268fdc4e70f2bb3520)