### PR TITLE
feat(ux): add unified ux_payload_v1 contract for mobile rendering

### DIFF
--- a/cv_engine/pipeline/analyze.py
+++ b/cv_engine/pipeline/analyze.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 # isort: skip_file
 from dataclasses import replace
 from time import perf_counter
-from typing import Any, Dict, Iterable, List, Tuple
+from typing import Any, Dict, Iterable, List, Literal, Tuple
 
 import numpy as np
 
@@ -75,6 +75,7 @@ def analyze_frames(
     model_variant: str | None = None,
     variant_source: str | None = None,
     calibration: CalibrationConfig | None = None,
+    mode: Literal["swing", "range"] | str = "swing",
 ) -> Dict[str, Any]:
     """Analyze sequence of frames for ball/club metrics."""
 
@@ -631,7 +632,7 @@ def analyze_frames(
         range_mode_hud=range_mode_hud,
         explain_result=metrics.get("explain_result"),
         micro_coach=metrics.get("micro_coach"),
-        mode="swing",
+        mode=mode,
     )
 
     return {

--- a/cv_engine/pipeline/analyze.py
+++ b/cv_engine/pipeline/analyze.py
@@ -27,6 +27,7 @@ from cv_engine.inference.model_registry import get_detection_engine
 from cv_engine.pose.adapter import PoseAdapter
 from cv_engine.sequence import analyze_kinematic_sequence
 from cv_engine.tracking.factory import get_ball_tracker, get_tracker
+from cv_engine.ux import build_ux_payload_v1
 from cv_engine.tracking.stabilizer import (
     BallDetection,
     compute_jitter_px,
@@ -625,6 +626,12 @@ def analyze_frames(
         or metrics.get("fit_v1")
         or metrics.get("calibration_v1"),
         max_tips=3,
+    )
+    metrics["ux_payload_v1"] = build_ux_payload_v1(
+        range_mode_hud=range_mode_hud,
+        explain_result=metrics.get("explain_result"),
+        micro_coach=metrics.get("micro_coach"),
+        mode="swing",
     )
 
     return {

--- a/cv_engine/tests/test_pipeline_mock.py
+++ b/cv_engine/tests/test_pipeline_mock.py
@@ -27,3 +27,17 @@ def test_pipeline_mock_is_deterministic():
 
     for key in ("ball_speed_mps", "ball_speed_mph", "launch_deg", "carry_m"):
         assert first["metrics"][key] == second["metrics"][key]
+
+
+def test_pipeline_range_mode_sets_ux_payload_mode():
+    frames = [np.zeros((64, 64, 3), dtype=np.uint8) for _ in range(10)]
+    calib = CalibrationParams.from_reference(1.0, 100.0, 120.0)
+    result = analyze_frames(
+        frames,
+        calib,
+        mock=True,
+        motion=(2.0, -1.0, 1.5, 0.0),
+        mode="range",
+    )
+
+    assert result["metrics"]["ux_payload_v1"]["mode"] == "range"

--- a/cv_engine/tests/test_ux_payload_v1.py
+++ b/cv_engine/tests/test_ux_payload_v1.py
@@ -1,0 +1,69 @@
+from cv_engine.coach.micro_coach_v1 import build_micro_coach_v1
+from cv_engine.explain.explain_result_v1 import build_explain_result_v1
+from cv_engine.ux.ux_payload_v1 import build_ux_payload_v1
+
+
+def test_build_ux_payload_v1_is_deterministic() -> None:
+    range_mode_hud = {
+        "state": "warn",
+        "score_0_100": 60,
+        "debug": {"flags": ["fps_low"]},
+    }
+    explain_result = build_explain_result_v1(
+        capture_guardrails=None,
+        range_mode_hud=range_mode_hud,
+        calibration=None,
+    )
+    micro_coach = build_micro_coach_v1(
+        explain_result=explain_result,
+        range_mode_hud=range_mode_hud,
+        max_tips=5,
+    )
+
+    first = build_ux_payload_v1(
+        range_mode_hud=range_mode_hud,
+        explain_result=explain_result,
+        micro_coach=micro_coach,
+        mode="range",
+    )
+    second = build_ux_payload_v1(
+        range_mode_hud=range_mode_hud,
+        explain_result=explain_result,
+        micro_coach=micro_coach,
+        mode="range",
+    )
+
+    assert first == second
+    assert first["version"] == "v1"
+    assert first["state"] == "WARN"
+    assert first["confidence"] == explain_result["confidence"]
+    assert len(first["coach"]["tips"]) <= 3
+
+
+def test_build_ux_payload_v1_handles_missing_inputs() -> None:
+    payload = build_ux_payload_v1(
+        range_mode_hud=None,
+        explain_result=None,
+        micro_coach=None,
+    )
+
+    assert payload["hud"] is None
+    assert payload["explain"] is None
+    assert payload["coach"] is None
+    assert payload["confidence"] is None
+    assert payload["state"] == "UNKNOWN"
+    assert payload["mode"] == "unknown"
+
+
+def test_build_ux_payload_v1_state_from_explain() -> None:
+    explain_result = {
+        "confidence": {"score": 20, "label": "LOW"},
+    }
+
+    payload = build_ux_payload_v1(
+        range_mode_hud=None,
+        explain_result=explain_result,
+        micro_coach=None,
+    )
+
+    assert payload["state"] == "BLOCK"

--- a/cv_engine/ux/__init__.py
+++ b/cv_engine/ux/__init__.py
@@ -1,0 +1,3 @@
+from .ux_payload_v1 import build_ux_payload_v1
+
+__all__ = ["build_ux_payload_v1"]

--- a/cv_engine/ux/ux_payload_v1.py
+++ b/cv_engine/ux/ux_payload_v1.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import is_dataclass
-from typing import Any
 
 from cv_engine.capture.range_mode_ux import RangeModeHUD
 

--- a/cv_engine/ux/ux_payload_v1.py
+++ b/cv_engine/ux/ux_payload_v1.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from dataclasses import is_dataclass
+from typing import Any
+
+from cv_engine.capture.range_mode_ux import RangeModeHUD
+
+_STATE_MAP = {
+    "ready": "READY",
+    "warn": "WARN",
+    "block": "BLOCK",
+}
+
+_CONFIDENCE_STATE_MAP = {
+    "HIGH": "READY",
+    "MED": "WARN",
+    "MEDIUM": "WARN",
+    "LOW": "BLOCK",
+}
+
+_ALLOWED_DEBUG_KEYS = ("case_id", "timestamps", "flags")
+
+
+def build_ux_payload_v1(
+    *,
+    range_mode_hud: dict | object | None,
+    explain_result: dict | None,
+    micro_coach: dict | None,
+    mode: str | None = None,
+    debug: dict[str, object] | None = None,
+    version: str = "v1",
+) -> dict[str, object]:
+    """Build a deterministic UX payload for mobile clients."""
+
+    hud_payload = _normalize_hud(range_mode_hud)
+    explain_payload = _normalize_payload(explain_result)
+    coach_payload = _normalize_micro_coach(micro_coach)
+    confidence_payload = _extract_confidence(explain_payload)
+
+    state = _derive_state(range_mode_hud, explain_payload)
+    mode_value = _normalize_mode(mode)
+    debug_payload = _normalize_debug(debug)
+
+    return {
+        "version": version,
+        "mode": mode_value,
+        "state": state,
+        "confidence": confidence_payload,
+        "hud": hud_payload,
+        "explain": explain_payload,
+        "coach": coach_payload,
+        "debug": debug_payload,
+    }
+
+
+def _normalize_mode(mode: str | None) -> str:
+    if isinstance(mode, str):
+        normalized = mode.lower()
+        if normalized in {"range", "swing", "unknown"}:
+            return normalized
+    return "unknown"
+
+
+def _derive_state(
+    range_mode_hud: dict | object | None, explain_result: dict | None
+) -> str:
+    range_state = _extract_range_state(range_mode_hud)
+    if range_state is not None:
+        return _normalize_state(range_state)
+
+    confidence_label = _extract_confidence_label(explain_result)
+    if confidence_label is None:
+        return "UNKNOWN"
+    return _CONFIDENCE_STATE_MAP.get(confidence_label, "UNKNOWN")
+
+
+def _normalize_state(state: str) -> str:
+    normalized = _STATE_MAP.get(state.lower())
+    if normalized is None:
+        return "UNKNOWN"
+    return normalized
+
+
+def _extract_range_state(range_mode_hud: dict | object | None) -> str | None:
+    if range_mode_hud is None:
+        return None
+    if isinstance(range_mode_hud, RangeModeHUD):
+        return range_mode_hud.state.value
+    if is_dataclass(range_mode_hud):
+        state = getattr(range_mode_hud, "state", None)
+        if isinstance(state, str):
+            return state
+        if hasattr(state, "value"):
+            return str(state.value)
+    if isinstance(range_mode_hud, dict):
+        state = range_mode_hud.get("state")
+        if isinstance(state, str):
+            return state
+    return None
+
+
+def _extract_confidence(explain_result: dict | None) -> dict[str, object] | None:
+    if not isinstance(explain_result, dict):
+        return None
+    confidence = explain_result.get("confidence")
+    if not isinstance(confidence, dict):
+        return None
+    score = confidence.get("score")
+    label = confidence.get("label")
+    if score is None or not isinstance(label, str):
+        return None
+    return {
+        "score": int(score),
+        "label": label,
+    }
+
+
+def _extract_confidence_label(explain_result: dict | None) -> str | None:
+    if not isinstance(explain_result, dict):
+        return None
+    confidence = explain_result.get("confidence")
+    if not isinstance(confidence, dict):
+        return None
+    label = confidence.get("label")
+    if not isinstance(label, str):
+        return None
+    return label.upper()
+
+
+def _normalize_hud(range_mode_hud: dict | object | None) -> dict | None:
+    if range_mode_hud is None:
+        return None
+    if isinstance(range_mode_hud, RangeModeHUD):
+        return range_mode_hud.to_dict()
+    if isinstance(range_mode_hud, dict):
+        return dict(range_mode_hud)
+    if is_dataclass(range_mode_hud):
+        to_dict = getattr(range_mode_hud, "to_dict", None)
+        if callable(to_dict):
+            return to_dict()
+    return None
+
+
+def _normalize_payload(payload: dict | None) -> dict | None:
+    if isinstance(payload, dict):
+        return dict(payload)
+    return None
+
+
+def _normalize_micro_coach(micro_coach: dict | None) -> dict | None:
+    if not isinstance(micro_coach, dict):
+        return None
+    normalized = dict(micro_coach)
+    tips = micro_coach.get("tips")
+    if isinstance(tips, list):
+        normalized["tips"] = list(tips)[:3]
+    return normalized
+
+
+def _normalize_debug(debug: dict[str, object] | None) -> dict[str, object] | None:
+    if not isinstance(debug, dict):
+        return None
+    normalized: dict[str, object] = {}
+    for key in _ALLOWED_DEBUG_KEYS:
+        if key in debug:
+            normalized[key] = debug[key]
+    return normalized or None

--- a/docs/ux_payload_v1.md
+++ b/docs/ux_payload_v1.md
@@ -1,0 +1,83 @@
+# UX Payload v1
+
+## Purpose
+`ux_payload_v1` provides a single, stable contract that mobile clients (iOS/Android)
+can render without understanding internal metrics. It unifies the range HUD,
+explainability, and micro-coach tips into one deterministic payload for premium UI
+and investor demos.
+
+## Schema
+```json
+{
+  "version": "v1",
+  "mode": "range" | "swing" | "unknown",
+  "state": "READY" | "WARN" | "BLOCK" | "UNKNOWN",
+  "confidence": {
+    "score": 0,
+    "label": "HIGH" | "MED" | "LOW"
+  },
+  "hud": { /* range_mode_hud payload */ },
+  "explain": { /* explain_result_v1 payload */ },
+  "coach": { /* micro_coach_v1 payload */ },
+  "debug": {
+    "case_id": "optional id",
+    "timestamps": { "optional": true },
+    "flags": ["optional", "flags"]
+  }
+}
+```
+
+### Field notes
+- `version`: contract version for mobile clients.
+- `mode`: capture context (`range` for range mode, `swing` for swing analysis).
+- `state`: user-facing readiness. Prefer range HUD state, otherwise derived from
+  explain confidence.
+- `confidence`: pass-through of explain confidence if available.
+- `hud`: range mode HUD payload (or `null` when unavailable).
+- `explain`: explainability payload (or `null` when unavailable).
+- `coach`: micro-coach payload (or `null` when unavailable, tips capped at 3).
+- `debug`: optional minimal debug metadata (kept intentionally small).
+
+## Example payloads
+
+### READY
+```json
+{
+  "version": "v1",
+  "mode": "swing",
+  "state": "READY",
+  "confidence": { "score": 92, "label": "HIGH" },
+  "hud": { "score_0_100": 92, "state": "ready" },
+  "explain": { "version": "v1", "confidence": { "score": 92, "label": "HIGH" } },
+  "coach": { "version": "v1", "enabled": true, "tips": [] },
+  "debug": null
+}
+```
+
+### WARN
+```json
+{
+  "version": "v1",
+  "mode": "range",
+  "state": "WARN",
+  "confidence": { "score": 62, "label": "MED" },
+  "hud": { "score_0_100": 62, "state": "warn" },
+  "explain": { "version": "v1", "confidence": { "score": 62, "label": "MED" } },
+  "coach": { "version": "v1", "enabled": true, "tips": [] },
+  "debug": { "flags": ["fps_low"] }
+}
+```
+
+### BLOCK
+```json
+{
+  "version": "v1",
+  "mode": "range",
+  "state": "BLOCK",
+  "confidence": { "score": 20, "label": "LOW" },
+  "hud": { "score_0_100": 20, "state": "block" },
+  "explain": { "version": "v1", "confidence": { "score": 20, "label": "LOW" } },
+  "coach": { "version": "v1", "enabled": true, "tips": [] },
+  "debug": null
+}
+```

--- a/server/cv/range_analyze.py
+++ b/server/cv/range_analyze.py
@@ -204,6 +204,7 @@ def run_real_analyze(
         model_variant=model_variant or payload.model_variant,
         variant_source=variant_source
         or ("range_analyze.model_variant" if payload.model_variant else None),
+        mode="range",
     )
     metrics_obj = result.get("metrics", {})
     metrics = dict(metrics_obj) if isinstance(metrics_obj, Mapping) else {}


### PR DESCRIPTION
### Motivation
- Unify existing `range_mode_hud`, `explain_result_v1`, and `micro_coach_v1` outputs into a single, stable payload that mobile apps can render without understanding internal metrics.
- Provide a deterministic, versioned contract for demos and premium UI that is tolerant of missing components and keeps payloads small.
- Ensure user-facing readiness (`state`) is predictable by preferring the HUD state and falling back to explain confidence.

### Description
- Add a new builder module `cv_engine/ux/ux_payload_v1.py` exposing `build_ux_payload_v1(...)` which normalizes subcomponents, derives `state`, exposes `confidence`, caps tips to 3, and produces a stable key ordering.
- Export the builder via `cv_engine/ux/__init__.py` and wire it into the pipeline so `metrics["ux_payload_v1"]` is produced in `cv_engine/pipeline/analyze.py` (keeps all existing outputs intact).
- Add documentation `docs/ux_payload_v1.md` describing purpose, schema, and three small example payloads (READY/WARN/BLOCK).
- Add unit tests `cv_engine/tests/test_ux_payload_v1.py` that assert `version == "v1"`, deterministic output, correct state mapping, tolerance to missing inputs, and that tips are capped.

### Testing
- Ran code formatting with `black` on the new files which completed successfully. 
- Added unit tests at `cv_engine/tests/test_ux_payload_v1.py` but `pytest` was not executed in this rollout. 
- No other automated checks (e.g., `ruff`/`pytest`) were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f918ddce48326aa47057f3d7426e6)