### PR TITLE
feat(api): expose ux_payload_v1 in analysis responses + demo mode

### DIFF
--- a/demo_assets/golden/block.json
+++ b/demo_assets/golden/block.json
@@ -339,5 +339,175 @@
     "segments_linked": 0,
     "stabilized": true
   },
+  "ux_payload_v1": {
+    "coach": {
+      "debug": {
+        "deduped_tip_ids": [
+          "tip_fps_light",
+          "tip_stabilize_phone",
+          "tip_even_lighting"
+        ],
+        "inputs_present": {
+          "calibration": true,
+          "explain_result": true,
+          "range_mode_hud": true
+        },
+        "selected_rule_ids": [
+          "tip_fps_light",
+          "tip_stabilize_phone",
+          "tip_even_lighting"
+        ]
+      },
+      "enabled": true,
+      "tips": [
+        {
+          "detail": "\u00d6ka belysningen s\u00e5 kameran kan k\u00f6ra snabbare bildhastighet.",
+          "id": "tip_fps_light",
+          "priority": 1,
+          "source": {
+            "action_ids": [
+              "increase_fps"
+            ],
+            "confidence_label": "LOW",
+            "hud_flags": [
+              "fps_low"
+            ],
+            "reason_ids": [
+              "fps_low"
+            ]
+          },
+          "title": "Mer ljus f\u00f6r h\u00f6gre FPS"
+        },
+        {
+          "detail": "St\u00f6d mobilen och undvik panorering s\u00e5 bollen blir skarp.",
+          "id": "tip_stabilize_phone",
+          "priority": 1,
+          "source": {
+            "action_ids": [
+              "reduce_blur"
+            ],
+            "confidence_label": "LOW",
+            "hud_flags": [
+              "blur_high"
+            ],
+            "reason_ids": [
+              "blur_high"
+            ]
+          },
+          "title": "Stabilisera kameran"
+        },
+        {
+          "detail": "Flytta till j\u00e4mnare ljus s\u00e5 bollen syns tydligt.",
+          "id": "tip_even_lighting",
+          "priority": 2,
+          "source": {
+            "action_ids": [
+              "improve_lighting"
+            ],
+            "confidence_label": "LOW",
+            "hud_flags": [
+              "exposure_too_dark"
+            ],
+            "reason_ids": [
+              "exposure_too_dark"
+            ]
+          },
+          "title": "J\u00e4mnare ljus"
+        }
+      ],
+      "version": "v1"
+    },
+    "confidence": {
+      "label": "LOW",
+      "score": 0
+    },
+    "debug": null,
+    "explain": {
+      "confidence": {
+        "label": "LOW",
+        "score": 0
+      },
+      "debug": {
+        "inputs_present": {
+          "calibration": true,
+          "guardrails": true,
+          "range_mode_hud": true
+        },
+        "signals_used": [
+          "fps_low",
+          "blur_high",
+          "exposure_too_dark"
+        ]
+      },
+      "version": "v1",
+      "what_to_do_now": [
+        {
+          "detail": "Enable slow-mo capture (120\u2013240 FPS).",
+          "id": "increase_fps",
+          "title": "Increase frame rate"
+        },
+        {
+          "detail": "Stabilize the phone or use faster shutter.",
+          "id": "reduce_blur",
+          "title": "Reduce blur"
+        },
+        {
+          "detail": "Brighten the hitting area and ball.",
+          "id": "improve_lighting",
+          "title": "Add lighting"
+        }
+      ],
+      "why_may_be_wrong": [
+        {
+          "detail": "Low FPS can miss the ball after impact.",
+          "id": "fps_low",
+          "title": "Low frame rate"
+        },
+        {
+          "detail": "Motion blur hides the ball in flight.",
+          "id": "blur_high",
+          "title": "Too much blur"
+        },
+        {
+          "detail": "The ball blends into a dark background.",
+          "id": "exposure_too_dark",
+          "title": "Too dark"
+        }
+      ]
+    },
+    "hud": {
+      "badges": [
+        "FPS",
+        "BLUR"
+      ],
+      "debug": {
+        "apply_hysteresis": false,
+        "flags": [
+          "fps_low",
+          "exposure_too_dark",
+          "blur_high"
+        ],
+        "hysteresis": {
+          "above_ready_count": 0,
+          "below_block_count": 0,
+          "state": "block"
+        },
+        "raw_state": "block",
+        "score_0_100": 45,
+        "single_eval": true
+      },
+      "primary_message": "Low frame rate",
+      "recommended_actions": [
+        "Switch to slow-mo (120\u2013240 FPS).",
+        "Stabilize the phone or use faster shutter."
+      ],
+      "score_0_100": 45,
+      "secondary_message": "Too much motion blur",
+      "state": "block"
+    },
+    "mode": "swing",
+    "state": "BLOCK",
+    "version": "v1"
+  },
   "vertLaunchDeg": 0.0
 }

--- a/demo_assets/golden/ready.json
+++ b/demo_assets/golden/ready.json
@@ -213,5 +213,101 @@
     "segments_linked": 0,
     "stabilized": true
   },
+  "ux_payload_v1": {
+    "coach": {
+      "debug": {
+        "deduped_tip_ids": [
+          "tip_redo_calibration"
+        ],
+        "inputs_present": {
+          "calibration": true,
+          "explain_result": true,
+          "range_mode_hud": true
+        },
+        "selected_rule_ids": [
+          "tip_redo_calibration"
+        ]
+      },
+      "enabled": true,
+      "tips": [
+        {
+          "detail": "Anv\u00e4nd tydliga mark\u00f6rer och r\u00e4tt avst\u00e5nd n\u00e4r du kalibrerar.",
+          "id": "tip_redo_calibration",
+          "priority": 3,
+          "source": {
+            "action_ids": [
+              "recalibrate_scale"
+            ],
+            "confidence_label": "HIGH",
+            "hud_flags": [],
+            "reason_ids": [
+              "calibration_low_confidence"
+            ]
+          },
+          "title": "G\u00f6r om kalibreringen"
+        }
+      ],
+      "version": "v1"
+    },
+    "confidence": {
+      "label": "HIGH",
+      "score": 75
+    },
+    "debug": null,
+    "explain": {
+      "confidence": {
+        "label": "HIGH",
+        "score": 75
+      },
+      "debug": {
+        "inputs_present": {
+          "calibration": true,
+          "guardrails": true,
+          "range_mode_hud": true
+        },
+        "signals_used": [
+          "calibration_low_confidence"
+        ]
+      },
+      "version": "v1",
+      "what_to_do_now": [
+        {
+          "detail": "Re-run calibration with clearer tracking.",
+          "id": "recalibrate_scale",
+          "title": "Recalibrate scale"
+        }
+      ],
+      "why_may_be_wrong": [
+        {
+          "detail": "Metric fit confidence is below target.",
+          "id": "calibration_low_confidence",
+          "title": "Calibration confidence low"
+        }
+      ]
+    },
+    "hud": {
+      "badges": [],
+      "debug": {
+        "apply_hysteresis": false,
+        "flags": [],
+        "hysteresis": {
+          "above_ready_count": 0,
+          "below_block_count": 0,
+          "state": "ready"
+        },
+        "raw_state": "ready",
+        "score_0_100": 100,
+        "single_eval": true
+      },
+      "primary_message": "Capture looks good",
+      "recommended_actions": [],
+      "score_0_100": 100,
+      "secondary_message": null,
+      "state": "ready"
+    },
+    "mode": "swing",
+    "state": "READY",
+    "version": "v1"
+  },
   "vertLaunchDeg": 0.0
 }

--- a/demo_assets/golden/warn.json
+++ b/demo_assets/golden/warn.json
@@ -301,5 +301,172 @@
     "segments_linked": 0,
     "stabilized": true
   },
+  "ux_payload_v1": {
+    "coach": {
+      "debug": {
+        "deduped_tip_ids": [
+          "tip_fps_light",
+          "tip_even_lighting",
+          "tip_redo_calibration"
+        ],
+        "inputs_present": {
+          "calibration": true,
+          "explain_result": true,
+          "range_mode_hud": true
+        },
+        "selected_rule_ids": [
+          "tip_fps_light",
+          "tip_even_lighting",
+          "tip_redo_calibration"
+        ]
+      },
+      "enabled": true,
+      "tips": [
+        {
+          "detail": "\u00d6ka belysningen s\u00e5 kameran kan k\u00f6ra snabbare bildhastighet.",
+          "id": "tip_fps_light",
+          "priority": 1,
+          "source": {
+            "action_ids": [
+              "increase_fps"
+            ],
+            "confidence_label": "LOW",
+            "hud_flags": [
+              "fps_low"
+            ],
+            "reason_ids": [
+              "fps_low"
+            ]
+          },
+          "title": "Mer ljus f\u00f6r h\u00f6gre FPS"
+        },
+        {
+          "detail": "Flytta till j\u00e4mnare ljus s\u00e5 bollen syns tydligt.",
+          "id": "tip_even_lighting",
+          "priority": 2,
+          "source": {
+            "action_ids": [
+              "improve_lighting"
+            ],
+            "confidence_label": "LOW",
+            "hud_flags": [
+              "exposure_too_dark"
+            ],
+            "reason_ids": [
+              "exposure_too_dark"
+            ]
+          },
+          "title": "J\u00e4mnare ljus"
+        },
+        {
+          "detail": "Anv\u00e4nd tydliga mark\u00f6rer och r\u00e4tt avst\u00e5nd n\u00e4r du kalibrerar.",
+          "id": "tip_redo_calibration",
+          "priority": 3,
+          "source": {
+            "action_ids": [
+              "recalibrate_scale"
+            ],
+            "confidence_label": "LOW",
+            "hud_flags": [],
+            "reason_ids": [
+              "calibration_low_confidence"
+            ]
+          },
+          "title": "G\u00f6r om kalibreringen"
+        }
+      ],
+      "version": "v1"
+    },
+    "confidence": {
+      "label": "LOW",
+      "score": 15
+    },
+    "debug": null,
+    "explain": {
+      "confidence": {
+        "label": "LOW",
+        "score": 15
+      },
+      "debug": {
+        "inputs_present": {
+          "calibration": true,
+          "guardrails": true,
+          "range_mode_hud": true
+        },
+        "signals_used": [
+          "fps_low",
+          "exposure_too_dark",
+          "calibration_low_confidence"
+        ]
+      },
+      "version": "v1",
+      "what_to_do_now": [
+        {
+          "detail": "Enable slow-mo capture (120\u2013240 FPS).",
+          "id": "increase_fps",
+          "title": "Increase frame rate"
+        },
+        {
+          "detail": "Brighten the hitting area and ball.",
+          "id": "improve_lighting",
+          "title": "Add lighting"
+        },
+        {
+          "detail": "Re-run calibration with clearer tracking.",
+          "id": "recalibrate_scale",
+          "title": "Recalibrate scale"
+        }
+      ],
+      "why_may_be_wrong": [
+        {
+          "detail": "Low FPS can miss the ball after impact.",
+          "id": "fps_low",
+          "title": "Low frame rate"
+        },
+        {
+          "detail": "The ball blends into a dark background.",
+          "id": "exposure_too_dark",
+          "title": "Too dark"
+        },
+        {
+          "detail": "Metric fit confidence is below target.",
+          "id": "calibration_low_confidence",
+          "title": "Calibration confidence low"
+        }
+      ]
+    },
+    "hud": {
+      "badges": [
+        "FPS",
+        "LIGHT"
+      ],
+      "debug": {
+        "apply_hysteresis": false,
+        "flags": [
+          "fps_low",
+          "exposure_too_dark"
+        ],
+        "hysteresis": {
+          "above_ready_count": 0,
+          "below_block_count": 0,
+          "state": "warn"
+        },
+        "raw_state": "warn",
+        "score_0_100": 65,
+        "single_eval": true
+      },
+      "primary_message": "Low frame rate",
+      "recommended_actions": [
+        "Switch to slow-mo (120\u2013240 FPS).",
+        "Increase light on the hitting area."
+      ],
+      "score_0_100": 65,
+      "secondary_message": "Scene is too dark",
+      "state": "warn"
+    },
+    "mode": "swing",
+    "state": "WARN",
+    "version": "v1"
+  },
   "vertLaunchDeg": 0.0
 }

--- a/docs/api_ux_payload_v1.md
+++ b/docs/api_ux_payload_v1.md
@@ -22,7 +22,8 @@ All analysis responses include:
 
 Add `demo=true` (or `demo=1`) to return deterministic, mock results without model
 loading. Demo responses include a concise `summary` field and a stable
-`ux_payload_v1`.
+`ux_payload_v1`. Demo mode forces a mock-safe detector variant and ignores
+`MODEL_VARIANT`.
 
 #### Example
 

--- a/docs/api_ux_payload_v1.md
+++ b/docs/api_ux_payload_v1.md
@@ -1,0 +1,73 @@
+# API: ux_payload_v1
+
+`ux_payload_v1` is the unified mobile UX contract returned by analysis endpoints.
+Clients should read the top-level `ux_payload_v1` field directly (no metrics parsing).
+
+## Endpoints
+
+| Endpoint | Mode | Notes |
+| --- | --- | --- |
+| `POST /cv/analyze` | swing | ZIP frame upload |
+| `POST /cv/analyze/video` | swing | Video upload |
+| `POST /range/practice/analyze` | range | Range practice capture |
+
+## Response Envelope
+
+All analysis responses include:
+
+- `ux_payload_v1`: unified UX payload (or `null` if unavailable)
+- existing fields (e.g., `metrics`, `events`, `run_id`) remain unchanged
+
+### Demo Mode
+
+Add `demo=true` (or `demo=1`) to return deterministic, mock results without model
+loading. Demo responses include a concise `summary` field and a stable
+`ux_payload_v1`.
+
+#### Example
+
+`POST /cv/analyze?demo=true`
+
+## Example JSON
+
+### Swing (cv analyze)
+
+```json
+{
+  "run_id": "run-123",
+  "events": [4],
+  "metrics": {"ball_speed_mps": 31.2},
+  "ux_payload_v1": {
+    "version": "v1",
+    "mode": "swing",
+    "state": "READY",
+    "confidence": {"score": 92, "label": "HIGH"},
+    "hud": null,
+    "explain": null,
+    "coach": null,
+    "debug": null
+  },
+  "summary": "demo mode: synthetic swing analysis"
+}
+```
+
+### Range (range practice)
+
+```json
+{
+  "run_id": "range-456",
+  "ball_speed_mps": 30.4,
+  "carry_m": 95.0,
+  "ux_payload_v1": {
+    "version": "v1",
+    "mode": "range",
+    "state": "READY",
+    "confidence": null,
+    "hud": {"state": "ready"},
+    "explain": null,
+    "coach": null,
+    "debug": null
+  },
+  "summary": "demo mode: synthetic range analysis"
+}
+```

--- a/server/cv/range_analyze.py
+++ b/server/cv/range_analyze.py
@@ -47,6 +47,10 @@ class RangeAnalyzeIn(BaseModel):
     model_variant: str | None = Field(
         default=None, description="Optional override for YOLO model variant"
     )
+    demo: bool = Field(
+        default=False,
+        description="Return a deterministic demo response without heavy ML",
+    )
 
 
 class CameraFitness(BaseModel):
@@ -65,6 +69,8 @@ class RangeAnalyzeOut(BaseModel):
     side_deg: float | None = None
     quality: CameraFitness | None = None
     run_id: str | None = None
+    ux_payload_v1: dict[str, Any] | None = None
+    summary: str | None = None
 
 
 _QUALITY_REASON_MAP: Dict[str, str] = {
@@ -143,6 +149,10 @@ def _build_out(metrics: Mapping[str, Any]) -> RangeAnalyzeOut:
         side_deg=side_deg,
         quality=camera,
     )
+
+
+def build_range_out(metrics: Mapping[str, Any]) -> RangeAnalyzeOut:
+    return _build_out(metrics)
 
 
 def _frames_from_payload(payload: RangeAnalyzeIn) -> Iterable[np.ndarray]:
@@ -259,6 +269,7 @@ __all__ = [
     "CameraFitness",
     "RangeAnalyzeIn",
     "RangeAnalyzeOut",
+    "build_range_out",
     "run_range_analyze",
     "run_mock_analyze",
     "run_real_analyze",

--- a/server/routes/cv_mock.py
+++ b/server/routes/cv_mock.py
@@ -47,6 +47,7 @@ class AnalyzeResponse(BaseModel):
     events: list[int]
     metrics: dict
     run_id: str
+    ux_payload_v1: dict | None = None
     error_code: str | None = None
     error_message: str | None = None
 
@@ -105,8 +106,12 @@ def analyze(req: AnalyzeRequest):
         inference_timing=timing,
         impact_preview=impact_preview,
     )
+    ux_payload = None
+    if isinstance(metrics, dict):
+        ux_payload = metrics.get("ux_payload_v1")
     return AnalyzeResponse(
         events=events,
         metrics=metrics,
         run_id=run.run_id,
+        ux_payload_v1=ux_payload,
     )

--- a/server/services/analysis_demo.py
+++ b/server/services/analysis_demo.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from cv_engine.metrics.kinematics import CalibrationParams
+from cv_engine.pipeline.analyze import analyze_frames
+from cv_engine.ux import build_ux_payload_v1
+
+
+_DEMO_FRAME_WIDTH = 64
+_DEMO_FRAME_HEIGHT = 64
+_DEMO_FRAME_COUNT = 12
+
+
+def demo_summary(mode: str) -> str:
+    normalized = mode.lower() if isinstance(mode, str) else "unknown"
+    return f"demo mode: synthetic {normalized} analysis"
+
+
+def run_demo_analysis(
+    *,
+    mode: str,
+    fps: float,
+    ref_len_m: float,
+    ref_len_px: float,
+    smoothing_window: int,
+    frames: int | None = None,
+    frame_width: int | None = None,
+    frame_height: int | None = None,
+) -> dict[str, Any]:
+    frame_count = max(frames or _DEMO_FRAME_COUNT, 2)
+    width = frame_width or _DEMO_FRAME_WIDTH
+    height = frame_height or _DEMO_FRAME_HEIGHT
+    synthetic_frames = [
+        np.zeros((height, width, 3), dtype=np.uint8) for _ in range(frame_count)
+    ]
+    calib = CalibrationParams.from_reference(ref_len_m, ref_len_px, fps)
+    return analyze_frames(
+        synthetic_frames,
+        calib,
+        mock=True,
+        smoothing_window=smoothing_window,
+        mode=mode,
+    )
+
+
+def ensure_ux_payload(metrics: dict[str, Any], *, mode: str) -> dict[str, Any]:
+    existing = metrics.get("ux_payload_v1")
+    if isinstance(existing, dict):
+        return existing
+
+    range_mode_hud = metrics.get("range_mode_hud")
+    capture_quality = metrics.get("capture_quality")
+    if range_mode_hud is None and isinstance(capture_quality, dict):
+        range_mode_hud = capture_quality.get("range_mode_hud")
+
+    payload = build_ux_payload_v1(
+        range_mode_hud=range_mode_hud,
+        explain_result=metrics.get("explain_result"),
+        micro_coach=metrics.get("micro_coach"),
+        mode=mode,
+    )
+    metrics["ux_payload_v1"] = payload
+    return payload
+
+
+__all__ = ["demo_summary", "run_demo_analysis", "ensure_ux_payload"]

--- a/server/services/analysis_demo.py
+++ b/server/services/analysis_demo.py
@@ -12,6 +12,7 @@ from cv_engine.ux import build_ux_payload_v1
 _DEMO_FRAME_WIDTH = 64
 _DEMO_FRAME_HEIGHT = 64
 _DEMO_FRAME_COUNT = 12
+DEMO_MODEL_VARIANT = "yolov10"
 
 
 def demo_summary(mode: str) -> str:
@@ -42,6 +43,7 @@ def run_demo_analysis(
         calib,
         mock=True,
         smoothing_window=smoothing_window,
+        model_variant=DEMO_MODEL_VARIANT,
         mode=mode,
     )
 
@@ -66,4 +68,9 @@ def ensure_ux_payload(metrics: dict[str, Any], *, mode: str) -> dict[str, Any]:
     return payload
 
 
-__all__ = ["demo_summary", "run_demo_analysis", "ensure_ux_payload"]
+__all__ = [
+    "DEMO_MODEL_VARIANT",
+    "demo_summary",
+    "run_demo_analysis",
+    "ensure_ux_payload",
+]

--- a/server/tests/test_ux_payload_api.py
+++ b/server/tests/test_ux_payload_api.py
@@ -38,3 +38,13 @@ def test_demo_mode_is_deterministic_for_cv_analyze() -> None:
     assert first.status_code == 200
     assert second.status_code == 200
     assert first.json()["ux_payload_v1"] == second.json()["ux_payload_v1"]
+
+
+def test_demo_mode_ignores_model_variant_env(monkeypatch) -> None:
+    monkeypatch.setenv("MODEL_VARIANT", "yolov11")
+    files = {"frames_zip": ("frames.zip", b"demo", "application/zip")}
+    with _make_client() as client:
+        resp = client.post("/cv/analyze?demo=true", files=files)
+
+    assert resp.status_code == 200
+    assert resp.json()["ux_payload_v1"]["mode"] == "swing"

--- a/server/tests/test_ux_payload_api.py
+++ b/server/tests/test_ux_payload_api.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from server.app import app
+
+
+def _make_client(**kwargs) -> TestClient:
+    return TestClient(app, **kwargs)
+
+
+def test_cv_analyze_demo_returns_swing_ux_payload() -> None:
+    files = {"frames_zip": ("frames.zip", b"demo", "application/zip")}
+    with _make_client() as client:
+        resp = client.post("/cv/analyze?demo=true", files=files)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ux_payload_v1"]["mode"] == "swing"
+    assert body["summary"] == "demo mode: synthetic swing analysis"
+
+
+def test_range_analyze_demo_returns_range_ux_payload() -> None:
+    with _make_client() as client:
+        resp = client.post("/range/practice/analyze", json={"frames": 8, "demo": True})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ux_payload_v1"]["mode"] == "range"
+
+
+def test_demo_mode_is_deterministic_for_cv_analyze() -> None:
+    files = {"frames_zip": ("frames.zip", b"demo", "application/zip")}
+    with _make_client() as client:
+        first = client.post("/cv/analyze?demo=1", files=files)
+        second = client.post("/cv/analyze?demo=1", files=files)
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json()["ux_payload_v1"] == second.json()["ux_payload_v1"]

--- a/server/tests/test_yolo_inference_flag.py
+++ b/server/tests/test_yolo_inference_flag.py
@@ -49,6 +49,7 @@ def test_cv_analyze_video_uses_mock_when_flag_disabled(
         smoothing_window,
         model_variant=None,
         variant_source=None,
+        mode=None,
     ):
         captured["mock"] = mock
         captured["model_variant"] = model_variant
@@ -79,6 +80,7 @@ def test_cv_analyze_video_uses_real_when_flag_enabled(
         smoothing_window,
         model_variant=None,
         variant_source=None,
+        mode=None,
     ):
         captured["mock"] = mock
         captured["model_variant"] = model_variant


### PR DESCRIPTION
### Motivation
- Mobile clients need a stable top-level `ux_payload_v1` contract from analysis endpoints so they can render the unified UX without parsing internal `metrics` structures.
- Endpoints must keep backward compatibility while correctly indicating `mode` for range vs swing use-cases.
- Provide a lightweight, deterministic `demo` mode to showcase analysis responses on machines without heavy ML models.

### Description
- Added a small demo helper service `server/services/analysis_demo.py` with `run_demo_analysis`, `ensure_ux_payload`, and `demo_summary` to generate deterministic synthetic analysis and to populate `ux_payload_v1` when missing.
- Exposed a `demo` flag on `POST /cv/analyze`, `POST /cv/analyze/video` and `POST /range/practice/analyze` and made demo requests run the mock pipeline using synthetic frames (no model loading), returning an optional `summary` and top-level `ux_payload_v1`.
- Extended response models and route handlers to include optional top-level `ux_payload_v1` and `summary`, preserved existing response keys, and threaded explicit `mode` values (`"swing"` for cv endpoints and `"range"` for range practice) down into `analyze_frames`.
- Updated `server/routes/cv_mock.py`, `server/cv/range_analyze.py`, docs (`docs/api_ux_payload_v1.md`), demo golden assets, and added fast server tests (`server/tests/test_ux_payload_api.py`) to validate swing/range/demo behavior.

### Testing
- Formatted changes with `python -m black .` which completed successfully.
- `python -m flake8 .` could not be executed in the environment due to a missing `flake8` installation.
- Ran the full test-suite with `python -m pytest -q` and all automated tests passed (1407 passed, 6 skipped), including the new fast API tests verifying `ux_payload_v1` presence, correct `mode` for swing/range endpoints, and demo determinism (`server/tests/test_ux_payload_api.py`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697083b287f08326ab70b0430c09965d)