### PR TITLE
feat(contract): add ux_payload_v1 JSON schema + validation + OpenAPI examples

### DIFF
--- a/docs/api_ux_payload_v1.md
+++ b/docs/api_ux_payload_v1.md
@@ -3,6 +3,12 @@
 `ux_payload_v1` is the unified mobile UX contract returned by analysis endpoints.
 Clients should read the top-level `ux_payload_v1` field directly (no metrics parsing).
 
+## Schema
+
+The canonical JSON Schema is available at:
+
+- [`docs/schemas/ux_payload_v1.schema.json`](schemas/ux_payload_v1.schema.json)
+
 ## Endpoints
 
 | Endpoint | Mode | Notes |
@@ -29,9 +35,17 @@ loading. Demo responses include a concise `summary` field and a stable
 
 `POST /cv/analyze?demo=true`
 
+## Compatibility policy
+
+- Clients should branch on `ux_payload_v1.version`.
+- Optional sub-objects (`hud`, `explain`, `coach`, `confidence`, `debug`) may be
+  `null` or omitted, so be tolerant when rendering.
+- Demo responses keep the same `mode` as the endpoint context (swing or range),
+  and include a concise `summary` at the top level.
+
 ## Example JSON
 
-### Swing (cv analyze)
+### Swing READY (cv analyze)
 
 ```json
 {
@@ -44,15 +58,14 @@ loading. Demo responses include a concise `summary` field and a stable
     "state": "READY",
     "confidence": {"score": 92, "label": "HIGH"},
     "hud": null,
-    "explain": null,
-    "coach": null,
+    "explain": {"version": "v1", "confidence": {"score": 92, "label": "HIGH"}},
+    "coach": {"version": "v1", "enabled": true, "tips": []},
     "debug": null
-  },
-  "summary": "demo mode: synthetic swing analysis"
+  }
 }
 ```
 
-### Range (range practice)
+### Range WARN (range practice)
 
 ```json
 {
@@ -62,13 +75,33 @@ loading. Demo responses include a concise `summary` field and a stable
   "ux_payload_v1": {
     "version": "v1",
     "mode": "range",
-    "state": "READY",
-    "confidence": null,
-    "hud": {"state": "ready"},
-    "explain": null,
-    "coach": null,
+    "state": "WARN",
+    "confidence": {"score": 62, "label": "MED"},
+    "hud": {"state": "warn", "score_0_100": 62},
+    "explain": {"version": "v1", "confidence": {"score": 62, "label": "MED"}},
+    "coach": {"version": "v1", "enabled": true, "tips": []},
+    "debug": {"flags": ["fps_low"]}
+  }
+}
+```
+
+### Demo BLOCK (cv analyze demo)
+
+```json
+{
+  "run_id": "demo-789",
+  "events": [4],
+  "metrics": {"ball_speed_mps": 21.4},
+  "ux_payload_v1": {
+    "version": "v1",
+    "mode": "swing",
+    "state": "BLOCK",
+    "confidence": {"score": 18, "label": "LOW"},
+    "hud": {"state": "block", "score_0_100": 18},
+    "explain": {"version": "v1", "confidence": {"score": 18, "label": "LOW"}},
+    "coach": {"version": "v1", "enabled": true, "tips": []},
     "debug": null
   },
-  "summary": "demo mode: synthetic range analysis"
+  "summary": "demo mode: synthetic swing analysis"
 }
 ```

--- a/docs/schemas/ux_payload_v1.schema.json
+++ b/docs/schemas/ux_payload_v1.schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://golfiq.ai/schemas/ux_payload_v1.schema.json",
+  "title": "UX Payload v1",
+  "type": "object",
+  "description": "Unified UX payload for mobile rendering.",
+  "additionalProperties": false,
+  "required": ["version", "mode", "state"],
+  "properties": {
+    "version": {
+      "type": "string",
+      "const": "v1",
+      "description": "Contract version for clients."
+    },
+    "mode": {
+      "type": "string",
+      "enum": ["swing", "range", "unknown"],
+      "description": "Capture context. Demo responses still report swing or range."
+    },
+    "state": {
+      "type": "string",
+      "enum": ["READY", "WARN", "BLOCK", "UNKNOWN"],
+      "description": "User-facing readiness derived from HUD or explain confidence."
+    },
+    "confidence": {
+      "type": ["object", "null"],
+      "description": "Explain confidence summary if available.",
+      "additionalProperties": false,
+      "required": ["score", "label"],
+      "properties": {
+        "score": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "label": {
+          "type": "string"
+        }
+      }
+    },
+    "hud": {
+      "type": ["object", "null"],
+      "description": "Normalized range HUD payload.",
+      "additionalProperties": true
+    },
+    "explain": {
+      "type": ["object", "null"],
+      "description": "Explainability payload if available.",
+      "additionalProperties": true
+    },
+    "coach": {
+      "type": ["object", "null"],
+      "description": "Micro-coach tips (max 3 tips) if available.",
+      "additionalProperties": true,
+      "properties": {
+        "tips": {
+          "type": "array",
+          "maxItems": 3,
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      }
+    },
+    "debug": {
+      "type": ["object", "null"],
+      "description": "Optional debug metadata.",
+      "additionalProperties": false,
+      "properties": {
+        "case_id": {"type": "string"},
+        "timestamps": {"type": "object", "additionalProperties": true},
+        "flags": {
+          "type": "array",
+          "items": {"type": "string"}
+        }
+      }
+    }
+  }
+}

--- a/server/tests/test_ux_payload_api.py
+++ b/server/tests/test_ux_payload_api.py
@@ -3,10 +3,20 @@ from __future__ import annotations
 from fastapi.testclient import TestClient
 
 from server.app import app
+from server.utils.schema_validate import validate_ux_payload_v1
 
 
 def _make_client(**kwargs) -> TestClient:
     return TestClient(app, **kwargs)
+
+
+def _assert_tips_capped(payload: dict[str, object]) -> None:
+    coach = payload.get("coach")
+    if not isinstance(coach, dict):
+        return
+    tips = coach.get("tips")
+    if isinstance(tips, list):
+        assert len(tips) <= 3
 
 
 def test_cv_analyze_demo_returns_swing_ux_payload() -> None:
@@ -17,6 +27,8 @@ def test_cv_analyze_demo_returns_swing_ux_payload() -> None:
     assert resp.status_code == 200
     body = resp.json()
     assert body["ux_payload_v1"]["mode"] == "swing"
+    validate_ux_payload_v1(body["ux_payload_v1"])
+    _assert_tips_capped(body["ux_payload_v1"])
     assert body["summary"] == "demo mode: synthetic swing analysis"
 
 
@@ -27,6 +39,8 @@ def test_range_analyze_demo_returns_range_ux_payload() -> None:
     assert resp.status_code == 200
     body = resp.json()
     assert body["ux_payload_v1"]["mode"] == "range"
+    validate_ux_payload_v1(body["ux_payload_v1"])
+    _assert_tips_capped(body["ux_payload_v1"])
 
 
 def test_demo_mode_is_deterministic_for_cv_analyze() -> None:
@@ -38,6 +52,20 @@ def test_demo_mode_is_deterministic_for_cv_analyze() -> None:
     assert first.status_code == 200
     assert second.status_code == 200
     assert first.json()["ux_payload_v1"] == second.json()["ux_payload_v1"]
+    validate_ux_payload_v1(first.json()["ux_payload_v1"])
+
+
+def test_demo_mode_is_deterministic_for_range_analyze() -> None:
+    with _make_client() as client:
+        first = client.post("/range/practice/analyze", json={"frames": 8, "demo": True})
+        second = client.post(
+            "/range/practice/analyze", json={"frames": 8, "demo": True}
+        )
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json()["ux_payload_v1"] == second.json()["ux_payload_v1"]
+    validate_ux_payload_v1(first.json()["ux_payload_v1"])
 
 
 def test_demo_mode_ignores_model_variant_env(monkeypatch) -> None:

--- a/server/utils/schema_validate.py
+++ b/server/utils/schema_validate.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+
+
+@lru_cache(maxsize=1)
+def _load_ux_payload_schema() -> dict[str, Any]:
+    root = Path(__file__).resolve().parents[2]
+    schema_path = root / "docs" / "schemas" / "ux_payload_v1.schema.json"
+    with schema_path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def validate_ux_payload_v1(payload: dict[str, Any]) -> None:
+    schema = _load_ux_payload_schema()
+    validator = jsonschema.Draft202012Validator(schema)
+    errors = sorted(validator.iter_errors(payload), key=lambda err: err.path)
+    if errors:
+        details = "\n".join(
+            f"- {'/'.join(str(part) for part in error.path)}: {error.message}"
+            for error in errors
+        )
+        raise AssertionError(f"ux_payload_v1 schema validation failed:\n{details}")


### PR DESCRIPTION
### Motivation
- Provide a typed, versioned JSON contract for `ux_payload_v1` so mobile clients can reliably render the UX payload. 
- Harden demo/swing/range responses with an explicit schema and deterministic checks while keeping existing response keys unchanged. 
- Fail fast on contract drift in tests to prevent accidental backend changes from breaking mobile rendering.

### Description
- Add the canonical JSON Schema at `docs/schemas/ux_payload_v1.schema.json` with `version`/`mode`/`state` requirements, top-level `additionalProperties: false`, and nested permissive structures and descriptions. 
- Add a validator helper `server/utils/schema_validate.py` that loads the schema and exposes `validate_ux_payload_v1(payload)` using `jsonschema`. 
- Extend server tests in `server/tests/test_ux_payload_api.py` to validate `ux_payload_v1` for `/cv/analyze` (demo), `/range/practice/analyze` (demo), assert `mode` consistency, enforce micro-coach `tips` length <= 3, and assert demo determinism for both swing and range. 
- Update API docs `docs/api_ux_payload_v1.md` to link the schema, add a short compatibility policy, and include copy-pasteable READY/WARN/BLOCK demo examples.

### Testing
- Ran `python -m pytest -q`, which completed successfully with `1409 passed, 6 skipped` and a small number of unrelated warnings. 
- New contract checks are exercised by the updated `server/tests/test_ux_payload_api.py` and passed under the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970a7f2d1c083268706f7545f95e459)